### PR TITLE
feat: JWT authentication & authorization (end-to-end)

### DIFF
--- a/backend/.env-example
+++ b/backend/.env-example
@@ -1,7 +1,37 @@
-# For local postgres container
-# DATABASE_URL=postgresql+asyncpg://studybuddy:studybuddy123@localhost:5432/studybuddy
+# JWT
+# Generate with: openssl rand -hex 32
+SECRET_KEY=<generate-with-openssl-rand-hex-32>
+ACCESS_TOKEN_EXPIRE_MINUTES=30
+REFRESH_TOKEN_EXPIRE_DAYS=7
+JWT_ISSUER=studybuddy-api
+JWT_AUDIENCE=studybuddy-client
 
+# Refresh-Token-Cookie (ADR-0001)
+# Dev: SameSite=lax + Secure=false for plain-HTTP localhost
+# Prod: SameSite=strict + Secure=true
+REFRESH_COOKIE_NAME=refresh_token
+REFRESH_COOKIE_PATH=/api/auth
+REFRESH_COOKIE_SAMESITE=lax
+REFRESH_COOKIE_SECURE=false
+
+# Redis (JWT-Denylist, Verify-Tokens, Rate-Limiter)
+REDIS_URL=redis://localhost:6379
+
+# Postgres
+# For local postgres container:
+# DATABASE_URL=postgresql+asyncpg://studybuddy:studybuddy123@localhost:5432/studybuddy
 DATABASE_URL=postgresql+asyncpg://studybuddy:<POSTGRES_PASSWORD>@85.215.241.173:5432/studybuddy
+
+# Mail (Mailpit locally, real SMTP provider in production)
+SMTP_HOST=localhost
+SMTP_PORT=1025
+SMTP_USER=
+SMTP_PASSWORD=
+SMTP_STARTTLS=false
+SMTP_SSL=false
+MAIL_FROM=no-reply@studybuddy.mojiverse.at
+MAIL_FROM_NAME=Study Buddy
+FRONTEND_BASE_URL=http://localhost:3000
 
 # MinIO
 MINIO_ENDPOINT=85.215.241.173:9000

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -13,8 +13,8 @@ class Settings(BaseSettings):
     JWT_AUDIENCE: str = "studybuddy-client"
     REDIS_URL: str = "redis://localhost:6379"
 
-    # Refresh-Token-Cookie (ADR-0001). Dev: SameSite=lax + Secure=false über plain HTTP localhost.
-    # Prod: SameSite=strict + Secure=true via .env überschreiben.
+    # Refresh token cookie (ADR-0001). Dev defaults: SameSite=lax + Secure=false for plain-HTTP localhost.
+    # Production: override via .env to SameSite=strict + Secure=true.
     REFRESH_COOKIE_NAME: str = "refresh_token"
     REFRESH_COOKIE_PATH: str = "/api/auth"
     REFRESH_COOKIE_SAMESITE: Literal["lax", "strict", "none"] = "lax"

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -13,6 +13,14 @@ class Settings(BaseSettings):
     JWT_AUDIENCE: str = "studybuddy-client"
     REDIS_URL: str = "redis://localhost:6379"
 
+    # Refresh-Token-Cookie (ADR-0001). Dev: SameSite=lax + Secure=false über plain HTTP localhost.
+    # Prod: SameSite=strict + Secure=true via .env überschreiben.
+    REFRESH_COOKIE_NAME: str = "refresh_token"
+    REFRESH_COOKIE_PATH: str = "/api/auth"
+    REFRESH_COOKIE_SAMESITE: Literal["lax", "strict", "none"] = "lax"
+    REFRESH_COOKIE_SECURE: bool = False
+    REFRESH_COOKIE_DOMAIN: str | None = None
+
     @field_validator("SECRET_KEY")
     @classmethod
     def secret_key_min_length(cls, v: str) -> str:

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -21,6 +21,17 @@ class Settings(BaseSettings):
     REFRESH_COOKIE_SECURE: bool = False
     REFRESH_COOKIE_DOMAIN: str | None = None
 
+    # Mail (Mailpit locally, real SMTP provider in production)
+    SMTP_HOST: str = "localhost"
+    SMTP_PORT: int = 1025
+    SMTP_USER: str = ""
+    SMTP_PASSWORD: str = ""
+    SMTP_STARTTLS: bool = False
+    SMTP_SSL: bool = False
+    MAIL_FROM: str = "no-reply@studybuddy.app"
+    MAIL_FROM_NAME: str = "Study Buddy"
+    FRONTEND_BASE_URL: str = "http://localhost:3000"
+
     @field_validator("SECRET_KEY")
     @classmethod
     def secret_key_min_length(cls, v: str) -> str:

--- a/backend/app/core/dependencies.py
+++ b/backend/app/core/dependencies.py
@@ -1,3 +1,5 @@
+from typing import Callable, Coroutine
+
 from fastapi import Depends, HTTPException, status
 from fastapi.security import OAuth2PasswordBearer
 from sqlalchemy import select
@@ -6,7 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.redis import is_token_denied
 from app.core.security import decode_token_payload
 from app.database.database import get_db
-from app.database.models import User
+from app.database.models import User, UserRole
 
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/api/auth/login")
 
@@ -49,3 +51,18 @@ async def get_current_active_user(
     if current_user.email_verified_at is None:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Email not verified")
     return current_user
+
+
+def require_role(role: UserRole) -> Callable[[User], Coroutine[None, None, User]]:
+    """Dependency factory: passes through the user only if their role matches."""
+    async def _checker(current_user: User = Depends(get_current_active_user)) -> User:
+        if current_user.role != role:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail=f"Requires {role.value} role",
+            )
+        return current_user
+    return _checker
+
+
+require_admin = require_role(UserRole.admin)

--- a/backend/app/core/dependencies.py
+++ b/backend/app/core/dependencies.py
@@ -13,11 +13,8 @@ from app.database.models import User, UserRole
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/api/auth/login")
 
 
-async def get_current_user(
-    token: str = Depends(oauth2_scheme),
-    db: AsyncSession = Depends(get_db),
-) -> User:
-    # Unified 401 for all failure cases — intentional, prevents user enumeration
+async def get_token_payload(token: str = Depends(oauth2_scheme)) -> dict:
+    """Validates the access token and returns the full payload (jti, exp, sub, ...)."""
     credentials_exception = HTTPException(
         status_code=status.HTTP_401_UNAUTHORIZED,
         detail="Could not validate credentials",
@@ -26,11 +23,22 @@ async def get_current_user(
     payload = decode_token_payload(token)
     if payload is None:
         raise credentials_exception
-
     jti = payload.get("jti")
     if jti is None or await is_token_denied(jti):
         raise credentials_exception
+    return payload
 
+
+async def get_current_user(
+    payload: dict = Depends(get_token_payload),
+    db: AsyncSession = Depends(get_db),
+) -> User:
+    # Unified 401 for all failure cases — intentional, prevents user enumeration
+    credentials_exception = HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Could not validate credentials",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
     try:
         user_id = int(payload["sub"])
     except (KeyError, ValueError, TypeError):

--- a/backend/app/core/limiter.py
+++ b/backend/app/core/limiter.py
@@ -1,0 +1,6 @@
+from slowapi import Limiter
+from slowapi.util import get_remote_address
+
+from app.core.config import settings
+
+limiter = Limiter(key_func=get_remote_address, storage_uri=settings.REDIS_URL)

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -1,5 +1,4 @@
 import hashlib
-import hmac
 import secrets
 import uuid
 from datetime import datetime, timedelta, timezone
@@ -66,10 +65,6 @@ def create_refresh_token() -> tuple[str, str]:
 
 def hash_refresh_token(raw_token: str) -> str:
     return _sha256_hex(raw_token)
-
-
-def verify_refresh_token_hash(raw_token: str, stored_hash: str) -> bool:
-    return hmac.compare_digest(_sha256_hex(raw_token), stored_hash)
 
 
 def get_refresh_token_expiry() -> datetime:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,12 +1,11 @@
 import logging
 
-from fastapi import FastAPI, Request
+from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from slowapi import Limiter, _rate_limit_exceeded_handler
+from slowapi import _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
-from slowapi.util import get_remote_address
 
-from app.core.config import settings
+from app.core.limiter import limiter
 from app.routes import auth, documents, search, filters
 from app.services.chroma_service import chroma_service
 
@@ -14,8 +13,6 @@ logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
 )
-
-limiter = Limiter(key_func=get_remote_address, storage_uri=settings.REDIS_URL)
 
 app = FastAPI(
     title="Study Buddy API",

--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -1,7 +1,7 @@
 import secrets
 from datetime import datetime, timedelta, timezone
 
-from fastapi import APIRouter, Depends, HTTPException, Request, status
+from fastapi import APIRouter, Cookie, Depends, HTTPException, Request, Response, status
 from fastapi.security import OAuth2PasswordRequestForm
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -25,6 +25,27 @@ from app.schemas.user import UserRegister, UserResponse, UserSetup
 router = APIRouter()
 
 
+def _set_refresh_cookie(response: Response, raw_refresh_token: str) -> None:
+    response.set_cookie(
+        key=settings.REFRESH_COOKIE_NAME,
+        value=raw_refresh_token,
+        max_age=settings.REFRESH_TOKEN_EXPIRE_DAYS * 24 * 60 * 60,
+        path=settings.REFRESH_COOKIE_PATH,
+        domain=settings.REFRESH_COOKIE_DOMAIN,
+        secure=settings.REFRESH_COOKIE_SECURE,
+        httponly=True,
+        samesite=settings.REFRESH_COOKIE_SAMESITE,
+    )
+
+
+def _clear_refresh_cookie(response: Response) -> None:
+    response.delete_cookie(
+        key=settings.REFRESH_COOKIE_NAME,
+        path=settings.REFRESH_COOKIE_PATH,
+        domain=settings.REFRESH_COOKIE_DOMAIN,
+    )
+
+
 @router.post("/register", response_model=UserResponse, status_code=status.HTTP_201_CREATED)
 async def register(body: UserRegister, db: AsyncSession = Depends(get_db)) -> User:
     result = await db.execute(select(User).where(User.email == body.email))
@@ -44,7 +65,11 @@ async def register(body: UserRegister, db: AsyncSession = Depends(get_db)) -> Us
 
 
 @router.post("/setup", response_model=TokenResponse)
-async def setup(body: UserSetup, db: AsyncSession = Depends(get_db)) -> TokenResponse:
+async def setup(
+    body: UserSetup,
+    response: Response,
+    db: AsyncSession = Depends(get_db),
+) -> TokenResponse:
     user_id = await consume_verify_token(body.token)
     if user_id is None:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid or expired verification token")
@@ -76,12 +101,14 @@ async def setup(body: UserSetup, db: AsyncSession = Depends(get_db)) -> TokenRes
     ))
     await db.commit()
 
-    return TokenResponse(access_token=access_token, refresh_token=raw_refresh)
+    _set_refresh_cookie(response, raw_refresh)
+    return TokenResponse(access_token=access_token)
 
 
 @router.post("/login", response_model=TokenResponse)
 async def login(
     request: Request,
+    response: Response,
     form_data: OAuth2PasswordRequestForm = Depends(),
     db: AsyncSession = Depends(get_db),
 ) -> TokenResponse:
@@ -112,17 +139,25 @@ async def login(
     db.add(db_refresh)
     await db.commit()
 
-    return TokenResponse(access_token=access_token, refresh_token=raw_refresh)
+    _set_refresh_cookie(response, raw_refresh)
+    return TokenResponse(access_token=access_token)
 
 
 @router.post("/refresh", response_model=TokenResponse)
-async def refresh_tokens(raw_refresh_token: str, db: AsyncSession = Depends(get_db)) -> TokenResponse:
+async def refresh_tokens(
+    response: Response,
+    refresh_token: str | None = Cookie(default=None, alias=settings.REFRESH_COOKIE_NAME),
+    db: AsyncSession = Depends(get_db),
+) -> TokenResponse:
+    if refresh_token is None:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Missing refresh token")
+
     result = await db.execute(
         select(RefreshToken).where(RefreshToken.revoked.is_(False))
     )
     stored: RefreshToken | None = None
     for row in result.scalars().all():
-        if verify_refresh_token_hash(raw_refresh_token, row.token_hash):
+        if verify_refresh_token_hash(refresh_token, row.token_hash):
             stored = row
             break
 
@@ -143,11 +178,13 @@ async def refresh_tokens(raw_refresh_token: str, db: AsyncSession = Depends(get_
     db.add(new_token)
     await db.commit()
 
-    return TokenResponse(access_token=access_token, refresh_token=raw_new)
+    _set_refresh_cookie(response, raw_new)
+    return TokenResponse(access_token=access_token)
 
 
 @router.post("/logout", status_code=status.HTTP_204_NO_CONTENT)
 async def logout(
+    response: Response,
     current_user: User = Depends(get_current_active_user),
     db: AsyncSession = Depends(get_db),
 ) -> None:
@@ -161,6 +198,8 @@ async def logout(
     for token in result.scalars().all():
         token.revoked = True
     await db.commit()
+
+    _clear_refresh_cookie(response)
 
 
 @router.get("/me", response_model=UserResponse)

--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -10,6 +10,7 @@ from app.core.config import settings
 from app.core.dependencies import get_current_active_user, get_token_payload
 from app.core.limiter import limiter
 from app.core.redis import consume_verify_token, denylist_token, store_verify_token
+from app.services.email_service import send_verify_email
 from app.core.security import (
     create_access_token,
     create_refresh_token,
@@ -65,7 +66,10 @@ async def register(
 
     verify_token = secrets.token_urlsafe(32)
     await store_verify_token(verify_token, user.id)
-    # TODO: send verify_token via email
+
+    accept_language = request.headers.get("accept-language", "")
+    locale = "de" if accept_language.lower().startswith("de") else "en"
+    await send_verify_email(user.email, verify_token, locale=locale)
 
     return user
 

--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -7,8 +7,8 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
-from app.core.dependencies import get_current_active_user
-from app.core.redis import consume_verify_token, store_verify_token
+from app.core.dependencies import get_current_active_user, get_token_payload
+from app.core.redis import consume_verify_token, denylist_token, store_verify_token
 from app.core.security import (
     create_access_token,
     create_refresh_token,
@@ -185,10 +185,20 @@ async def refresh_tokens(
 @router.post("/logout", status_code=status.HTTP_204_NO_CONTENT)
 async def logout(
     response: Response,
+    payload: dict = Depends(get_token_payload),
     current_user: User = Depends(get_current_active_user),
     db: AsyncSession = Depends(get_db),
 ) -> None:
-    # Revoke all active refresh tokens for this user
+    # Denylist the access token JTI so it cannot be reused before exp.
+    # TTL equals the token's remaining lifetime — Redis evicts the entry afterwards.
+    jti = payload.get("jti")
+    exp = payload.get("exp")
+    if jti and isinstance(exp, int):
+        now_ts = int(datetime.now(timezone.utc).timestamp())
+        remaining = exp - now_ts
+        if remaining > 0:
+            await denylist_token(jti, remaining)
+
     result = await db.execute(
         select(RefreshToken).where(
             RefreshToken.user_id == current_user.id,

--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -8,6 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
 from app.core.dependencies import get_current_active_user, get_token_payload
+from app.core.limiter import limiter
 from app.core.redis import consume_verify_token, denylist_token, store_verify_token
 from app.core.security import (
     create_access_token,
@@ -47,7 +48,12 @@ def _clear_refresh_cookie(response: Response) -> None:
 
 
 @router.post("/register", response_model=UserResponse, status_code=status.HTTP_201_CREATED)
-async def register(body: UserRegister, db: AsyncSession = Depends(get_db)) -> User:
+@limiter.limit("3/minute")
+async def register(
+    request: Request,
+    body: UserRegister,
+    db: AsyncSession = Depends(get_db),
+) -> User:
     result = await db.execute(select(User).where(User.email == body.email))
     if result.scalar_one_or_none() is not None:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Email already registered")
@@ -65,7 +71,9 @@ async def register(body: UserRegister, db: AsyncSession = Depends(get_db)) -> Us
 
 
 @router.post("/setup", response_model=TokenResponse)
+@limiter.limit("5/minute")
 async def setup(
+    request: Request,
     body: UserSetup,
     response: Response,
     db: AsyncSession = Depends(get_db),
@@ -106,6 +114,7 @@ async def setup(
 
 
 @router.post("/login", response_model=TokenResponse)
+@limiter.limit("5/minute")
 async def login(
     request: Request,
     response: Response,
@@ -144,7 +153,9 @@ async def login(
 
 
 @router.post("/refresh", response_model=TokenResponse)
+@limiter.limit("10/minute")
 async def refresh_tokens(
+    request: Request,
     response: Response,
     refresh_token: str | None = Cookie(default=None, alias=settings.REFRESH_COOKIE_NAME),
     db: AsyncSession = Depends(get_db),

--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -16,8 +16,8 @@ from app.core.security import (
     create_refresh_token,
     get_password_hash,
     get_refresh_token_expiry,
+    hash_refresh_token,
     verify_password,
-    verify_refresh_token_hash,
 )
 from app.database.database import get_db
 from app.database.models import RefreshToken, User
@@ -167,14 +167,16 @@ async def refresh_tokens(
     if refresh_token is None:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Missing refresh token")
 
+    # Indexed lookup on token_hash — SHA-256 of the raw token. The hash is
+    # deterministic, so a direct WHERE clause is O(log n) via the index.
+    token_hash = hash_refresh_token(refresh_token)
     result = await db.execute(
-        select(RefreshToken).where(RefreshToken.revoked.is_(False))
+        select(RefreshToken).where(
+            RefreshToken.token_hash == token_hash,
+            RefreshToken.revoked.is_(False),
+        )
     )
-    stored: RefreshToken | None = None
-    for row in result.scalars().all():
-        if verify_refresh_token_hash(refresh_token, row.token_hash):
-            stored = row
-            break
+    stored = result.scalar_one_or_none()
 
     if stored is None or stored.expires_at < datetime.now(timezone.utc):
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid or expired refresh token")

--- a/backend/app/routes/documents.py
+++ b/backend/app/routes/documents.py
@@ -6,8 +6,9 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
+from app.core.dependencies import get_current_active_user
 from app.database.database import get_db
-from app.database.models import Document, Subject
+from app.database.models import Document, Subject, User
 from app.schemas.document import DocumentResponse
 from app.repositories.crud import get_category_or_404, get_document_or_404, get_subject_or_404
 from app.services.document_service import extract_text_from_bytes
@@ -16,6 +17,15 @@ from app.services.minio_service import upload_file, get_presigned_url, delete_fi
 
 router = APIRouter()
 
+ALLOWED_MIME_TYPES = {
+    ".pdf": "application/pdf",
+    ".docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    ".txt": "text/plain",
+    ".md": "text/plain",
+}
+ALLOWED_EXTENSIONS = set(ALLOWED_MIME_TYPES.keys())
+MAX_UPLOAD_BYTES = 50 * 1024 * 1024  # 50 MB
+
 
 @router.post("/upload", response_model=DocumentResponse)
 async def upload_document(
@@ -23,16 +33,9 @@ async def upload_document(
     category_id: int | None = Form(None),
     subject_id: int | None = Form(None),
     tags: str | None = Form(None),
-    db: AsyncSession = Depends(get_db)
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
 ) -> DocumentResponse:
-    ALLOWED_EXTENSIONS = {".pdf", ".docx", ".txt", ".md"}
-    ALLOWED_MIME_TYPES = {
-        ".pdf": "application/pdf",
-        ".docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-        ".txt": "text/plain",
-        ".md": "text/plain",
-    }
-
     file_ext = os.path.splitext(file.filename)[1].lower()
 
     if file_ext not in ALLOWED_EXTENSIONS:
@@ -47,7 +50,6 @@ async def upload_document(
     if subject_id is not None:
         await get_subject_or_404(db, subject_id)
 
-    MAX_UPLOAD_BYTES = 50 * 1024 * 1024  # 50 MB
     file_content = await file.read(MAX_UPLOAD_BYTES + 1)
     if len(file_content) > MAX_UPLOAD_BYTES:
         raise HTTPException(status_code=413, detail="File too large. Maximum allowed size is 50 MB.")
@@ -77,6 +79,7 @@ async def upload_document(
         file_url=get_file_url(object_key),
         category_id=category_id,
         subject_id=subject_id,
+        uploaded_by=current_user.id,
     )
 
     db.add(db_document)
@@ -160,7 +163,11 @@ async def get_download_url(document_id: int, db: AsyncSession = Depends(get_db))
 
 
 @router.delete("/{document_id}")
-async def delete_document(document_id: int, db: AsyncSession = Depends(get_db)) -> dict[str, str]:
+async def delete_document(
+    document_id: int,
+    db: AsyncSession = Depends(get_db),
+    _current_user: User = Depends(get_current_active_user),
+) -> dict[str, str]:
     document = await get_document_or_404(db, document_id)
 
     delete_file(document.filename)

--- a/backend/app/routes/documents.py
+++ b/backend/app/routes/documents.py
@@ -1,14 +1,14 @@
 import os
 
 import magic
-from fastapi import APIRouter, UploadFile, File, Form, Depends, HTTPException
+from fastapi import APIRouter, UploadFile, File, Form, Depends, HTTPException, status
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from app.core.dependencies import get_current_active_user
 from app.database.database import get_db
-from app.database.models import Document, Subject, User
+from app.database.models import Document, Subject, User, UserRole
 from app.schemas.document import DocumentResponse
 from app.repositories.crud import get_category_or_404, get_document_or_404, get_subject_or_404
 from app.services.document_service import extract_text_from_bytes
@@ -166,9 +166,20 @@ async def get_download_url(document_id: int, db: AsyncSession = Depends(get_db))
 async def delete_document(
     document_id: int,
     db: AsyncSession = Depends(get_db),
-    _current_user: User = Depends(get_current_active_user),
+    current_user: User = Depends(get_current_active_user),
 ) -> dict[str, str]:
     document = await get_document_or_404(db, document_id)
+
+    # Only the uploader or an admin can delete. uploaded_by may be NULL for
+    # documents whose uploader was deleted (SET NULL on user delete) — those
+    # are admin-only by design.
+    is_owner = document.uploaded_by is not None and document.uploaded_by == current_user.id
+    is_admin = current_user.role == UserRole.admin
+    if not (is_owner or is_admin):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Not allowed to delete this document",
+        )
 
     delete_file(document.filename)
 

--- a/backend/app/routes/filters.py
+++ b/backend/app/routes/filters.py
@@ -3,7 +3,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
-from app.core.dependencies import get_current_active_user
+from app.core.dependencies import require_admin
 from app.database.database import get_db
 from app.database.models import Semester, Subject, Category, Document, User
 from app.repositories.crud import get_semester_or_404, get_subject_or_404, get_category_or_404
@@ -33,7 +33,7 @@ async def list_semesters(db: AsyncSession = Depends(get_db)) -> list[SemesterRes
 async def create_semester(
     semester: SemesterCreate,
     db: AsyncSession = Depends(get_db),
-    _current_user: User = Depends(get_current_active_user),
+    _current_user: User = Depends(require_admin),
 ) -> SemesterResponse:
     existing = (await db.execute(select(Semester).filter(Semester.name == semester.name))).scalars().first()
     if existing:
@@ -59,7 +59,7 @@ async def list_subjects(semester_id: int | None = None, db: AsyncSession = Depen
 async def create_subject(
     subject: SubjectCreate,
     db: AsyncSession = Depends(get_db),
-    _current_user: User = Depends(get_current_active_user),
+    _current_user: User = Depends(require_admin),
 ) -> SubjectResponse:
     await get_semester_or_404(db, subject.semester_id)
 
@@ -80,7 +80,7 @@ async def list_categories(db: AsyncSession = Depends(get_db)) -> list[CategoryRe
 async def create_category(
     category: CategoryCreate,
     db: AsyncSession = Depends(get_db),
-    _current_user: User = Depends(get_current_active_user),
+    _current_user: User = Depends(require_admin),
 ) -> CategoryResponse:
     existing = (await db.execute(select(Category).filter(Category.name == category.name))).scalars().first()
     if existing:
@@ -97,7 +97,7 @@ async def create_category(
 async def delete_semester(
     semester_id: int,
     db: AsyncSession = Depends(get_db),
-    _current_user: User = Depends(get_current_active_user),
+    _current_user: User = Depends(require_admin),
 ) -> dict[str, str]:
     semester = await get_semester_or_404(db, semester_id)
 
@@ -114,7 +114,7 @@ async def delete_semester(
 async def delete_subject(
     subject_id: int,
     db: AsyncSession = Depends(get_db),
-    _current_user: User = Depends(get_current_active_user),
+    _current_user: User = Depends(require_admin),
 ) -> dict[str, str]:
     subject = await get_subject_or_404(db, subject_id)
 
@@ -131,7 +131,7 @@ async def delete_subject(
 async def delete_category(
     category_id: int,
     db: AsyncSession = Depends(get_db),
-    _current_user: User = Depends(get_current_active_user),
+    _current_user: User = Depends(require_admin),
 ) -> dict[str, str]:
     category = await get_category_or_404(db, category_id)
 

--- a/backend/app/routes/filters.py
+++ b/backend/app/routes/filters.py
@@ -3,8 +3,9 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
+from app.core.dependencies import get_current_active_user
 from app.database.database import get_db
-from app.database.models import Semester, Subject, Category, Document
+from app.database.models import Semester, Subject, Category, Document, User
 from app.repositories.crud import get_semester_or_404, get_subject_or_404, get_category_or_404
 from app.schemas.semester import SemesterResponse, SemesterCreate
 from app.schemas.subject import SubjectResponse, SubjectCreate
@@ -29,7 +30,11 @@ async def list_semesters(db: AsyncSession = Depends(get_db)) -> list[SemesterRes
 
 
 @router.post("/semesters", response_model=SemesterResponse)
-async def create_semester(semester: SemesterCreate, db: AsyncSession = Depends(get_db)) -> SemesterResponse:
+async def create_semester(
+    semester: SemesterCreate,
+    db: AsyncSession = Depends(get_db),
+    _current_user: User = Depends(get_current_active_user),
+) -> SemesterResponse:
     existing = (await db.execute(select(Semester).filter(Semester.name == semester.name))).scalars().first()
     if existing:
         raise HTTPException(status_code=400, detail="Semester already exists")
@@ -51,7 +56,11 @@ async def list_subjects(semester_id: int | None = None, db: AsyncSession = Depen
 
 
 @router.post("/subjects", response_model=SubjectResponse)
-async def create_subject(subject: SubjectCreate, db: AsyncSession = Depends(get_db)) -> SubjectResponse:
+async def create_subject(
+    subject: SubjectCreate,
+    db: AsyncSession = Depends(get_db),
+    _current_user: User = Depends(get_current_active_user),
+) -> SubjectResponse:
     await get_semester_or_404(db, subject.semester_id)
 
     db_subject = Subject(name=subject.name, semester_id=subject.semester_id)
@@ -68,7 +77,11 @@ async def list_categories(db: AsyncSession = Depends(get_db)) -> list[CategoryRe
 
 
 @router.post("/categories", response_model=CategoryResponse)
-async def create_category(category: CategoryCreate, db: AsyncSession = Depends(get_db)) -> CategoryResponse:
+async def create_category(
+    category: CategoryCreate,
+    db: AsyncSession = Depends(get_db),
+    _current_user: User = Depends(get_current_active_user),
+) -> CategoryResponse:
     existing = (await db.execute(select(Category).filter(Category.name == category.name))).scalars().first()
     if existing:
         raise HTTPException(status_code=400, detail="Category already exists")
@@ -81,7 +94,11 @@ async def create_category(category: CategoryCreate, db: AsyncSession = Depends(g
 
 
 @router.delete("/semesters/{semester_id}")
-async def delete_semester(semester_id: int, db: AsyncSession = Depends(get_db)) -> dict[str, str]:
+async def delete_semester(
+    semester_id: int,
+    db: AsyncSession = Depends(get_db),
+    _current_user: User = Depends(get_current_active_user),
+) -> dict[str, str]:
     semester = await get_semester_or_404(db, semester_id)
 
     has_subjects = (await db.execute(select(Subject).filter(Subject.semester_id == semester_id))).scalars().first()
@@ -94,7 +111,11 @@ async def delete_semester(semester_id: int, db: AsyncSession = Depends(get_db)) 
 
 
 @router.delete("/subjects/{subject_id}")
-async def delete_subject(subject_id: int, db: AsyncSession = Depends(get_db)) -> dict[str, str]:
+async def delete_subject(
+    subject_id: int,
+    db: AsyncSession = Depends(get_db),
+    _current_user: User = Depends(get_current_active_user),
+) -> dict[str, str]:
     subject = await get_subject_or_404(db, subject_id)
 
     has_documents = (await db.execute(select(Document).filter(Document.subject_id == subject_id))).scalars().first()
@@ -107,7 +128,11 @@ async def delete_subject(subject_id: int, db: AsyncSession = Depends(get_db)) ->
 
 
 @router.delete("/categories/{category_id}")
-async def delete_category(category_id: int, db: AsyncSession = Depends(get_db)) -> dict[str, str]:
+async def delete_category(
+    category_id: int,
+    db: AsyncSession = Depends(get_db),
+    _current_user: User = Depends(get_current_active_user),
+) -> dict[str, str]:
     category = await get_category_or_404(db, category_id)
 
     has_documents = (await db.execute(select(Document).filter(Document.category_id == category_id))).scalars().first()

--- a/backend/app/schemas/token.py
+++ b/backend/app/schemas/token.py
@@ -5,7 +5,6 @@ from pydantic import BaseModel, ConfigDict
 
 class TokenResponse(BaseModel):
     access_token: str
-    refresh_token: str
     token_type: str = "bearer"
 
 

--- a/backend/app/services/email_service.py
+++ b/backend/app/services/email_service.py
@@ -1,0 +1,77 @@
+import logging
+from typing import Literal
+from urllib.parse import urlencode
+
+from fastapi_mail import ConnectionConfig, FastMail, MessageSchema, MessageType
+from pydantic import SecretStr
+
+from app.core.config import settings
+
+logger = logging.getLogger(__name__)
+
+Locale = Literal["de", "en"]
+
+
+_connection_config = ConnectionConfig(
+    MAIL_USERNAME=settings.SMTP_USER,
+    MAIL_PASSWORD=SecretStr(settings.SMTP_PASSWORD),
+    MAIL_FROM=settings.MAIL_FROM,
+    MAIL_FROM_NAME=settings.MAIL_FROM_NAME,
+    MAIL_PORT=settings.SMTP_PORT,
+    MAIL_SERVER=settings.SMTP_HOST,
+    MAIL_STARTTLS=settings.SMTP_STARTTLS,
+    MAIL_SSL_TLS=settings.SMTP_SSL,
+    USE_CREDENTIALS=bool(settings.SMTP_USER),
+    VALIDATE_CERTS=settings.SMTP_SSL or settings.SMTP_STARTTLS,
+)
+
+_mailer = FastMail(_connection_config)
+
+
+_VERIFY_SUBJECT = {
+    "de": "Bestätige deine Study Buddy E-Mail",
+    "en": "Confirm your Study Buddy email",
+}
+
+
+def _verify_email_html(setup_url: str, locale: Locale) -> str:
+    if locale == "de":
+        return f"""\
+<!doctype html>
+<html><body style="font-family: system-ui, sans-serif; color: #111;">
+  <h2>Willkommen bei Study Buddy</h2>
+  <p>Klicke auf den folgenden Link, um dein Konto einzurichten:</p>
+  <p><a href="{setup_url}" style="background:#0a0a0a;color:#fff;padding:10px 16px;text-decoration:none;border-radius:6px;">Konto einrichten</a></p>
+  <p style="font-size:12px;color:#666;">Wenn der Button nicht funktioniert, kopiere diese URL in deinen Browser:<br>{setup_url}</p>
+  <p style="font-size:12px;color:#666;">Der Link ist 24 Stunden gültig.</p>
+</body></html>
+"""
+    return f"""\
+<!doctype html>
+<html><body style="font-family: system-ui, sans-serif; color: #111;">
+  <h2>Welcome to Study Buddy</h2>
+  <p>Click the link below to finish setting up your account:</p>
+  <p><a href="{setup_url}" style="background:#0a0a0a;color:#fff;padding:10px 16px;text-decoration:none;border-radius:6px;">Set up account</a></p>
+  <p style="font-size:12px;color:#666;">If the button doesn't work, copy this URL into your browser:<br>{setup_url}</p>
+  <p style="font-size:12px;color:#666;">The link is valid for 24 hours.</p>
+</body></html>
+"""
+
+
+async def send_verify_email(to_email: str, verify_token: str, locale: Locale = "en") -> None:
+    """Send the account-setup link to the given address. Failures are logged but
+    not raised — the user-facing endpoint must not leak SMTP errors."""
+    query = urlencode({"token": verify_token})
+    setup_url = f"{settings.FRONTEND_BASE_URL}/setup?{query}"
+
+    message = MessageSchema(
+        subject=_VERIFY_SUBJECT[locale],
+        recipients=[to_email],
+        body=_verify_email_html(setup_url, locale),
+        subtype=MessageType.html,
+    )
+
+    try:
+        await _mailer.send_message(message)
+    except Exception:
+        logger.exception("Failed to send verify email to %s", to_email)

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "docutils==0.22.3",
     "durationpy==0.10",
     "fastapi==0.119.0",
+    "fastapi-mail>=1.5.8",
     "filelock==3.20.0",
     "flatbuffers==25.9.23",
     "fsspec==2025.9.0",

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -7,6 +7,15 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "aiosmtplib"
+version = "4.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/e1/cc58e0be242f0b410707e001ed22c689435964fcaab42108887426e44fff/aiosmtplib-4.0.2.tar.gz", hash = "sha256:f0b4933e7270a8be2b588761e5b12b7334c11890ee91987c2fb057e72f566da6", size = 61052, upload-time = "2025-08-25T02:39:07.249Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/2f/db9414bbeacee48ab0c7421a0319b361b7c15b5c3feebcd38684f5d5f849/aiosmtplib-4.0.2-py3-none-any.whl", hash = "sha256:72491f96e6de035c28d29870186782eccb2f651db9c5f8a32c9db689327f5742", size = 27048, upload-time = "2025-08-25T02:39:06.089Z" },
+]
+
+[[package]]
 name = "alabaster"
 version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -204,6 +213,15 @@ wheels = [
 ]
 
 [[package]]
+name = "blinker"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/28/9b3f50ce0e048515135495f198351908d99540d69bfdc8c1d15b73dc55ce/blinker-1.9.0.tar.gz", hash = "sha256:b4ce2265a7abece45e7cc896e98dbebe6cead56bcf805a3d23136d145f5445bf", size = 22460, upload-time = "2024-11-08T17:25:47.436Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/cb/f2ad4230dc2eb1a74edf38f1a38b9b52277f75bef262d8908e60d957e13c/blinker-1.9.0-py3-none-any.whl", hash = "sha256:ba0efaa9080b619ff2f3459d1d500c57bddea4a6b424b60a91141db6fd2f08bc", size = 8458, upload-time = "2024-11-08T17:25:46.184Z" },
+]
+
+[[package]]
 name = "build"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -397,6 +415,59 @@ wheels = [
 ]
 
 [[package]]
+name = "cryptography"
+version = "46.0.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/47/93/ac8f3d5ff04d54bc814e961a43ae5b0b146154c89c61b47bb07557679b18/cryptography-46.0.7.tar.gz", hash = "sha256:e4cfd68c5f3e0bfdad0d38e023239b96a2fe84146481852dffbcca442c245aa5", size = 750652, upload-time = "2026-04-08T01:57:54.692Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/5d/4a8f770695d73be252331e60e526291e3df0c9b27556a90a6b47bccca4c2/cryptography-46.0.7-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:ea42cbe97209df307fdc3b155f1b6fa2577c0defa8f1f7d3be7d31d189108ad4", size = 7179869, upload-time = "2026-04-08T01:56:17.157Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/45/6d80dc379b0bbc1f9d1e429f42e4cb9e1d319c7a8201beffd967c516ea01/cryptography-46.0.7-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b36a4695e29fe69215d75960b22577197aca3f7a25b9cf9d165dcfe9d80bc325", size = 4275492, upload-time = "2026-04-08T01:56:19.36Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/9a/1765afe9f572e239c3469f2cb429f3ba7b31878c893b246b4b2994ffe2fe/cryptography-46.0.7-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5ad9ef796328c5e3c4ceed237a183f5d41d21150f972455a9d926593a1dcb308", size = 4426670, upload-time = "2026-04-08T01:56:21.415Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/3e/af9246aaf23cd4ee060699adab1e47ced3f5f7e7a8ffdd339f817b446462/cryptography-46.0.7-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:73510b83623e080a2c35c62c15298096e2a5dc8d51c3b4e1740211839d0dea77", size = 4280275, upload-time = "2026-04-08T01:56:23.539Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/54/6bbbfc5efe86f9d71041827b793c24811a017c6ac0fd12883e4caa86b8ed/cryptography-46.0.7-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:cbd5fb06b62bd0721e1170273d3f4d5a277044c47ca27ee257025146c34cbdd1", size = 4928402, upload-time = "2026-04-08T01:56:25.624Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/cf/054b9d8220f81509939599c8bdbc0c408dbd2bdd41688616a20731371fe0/cryptography-46.0.7-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:420b1e4109cc95f0e5700eed79908cef9268265c773d3a66f7af1eef53d409ef", size = 4459985, upload-time = "2026-04-08T01:56:27.309Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/46/4e4e9c6040fb01c7467d47217d2f882daddeb8828f7df800cb806d8a2288/cryptography-46.0.7-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:24402210aa54baae71d99441d15bb5a1919c195398a87b563df84468160a65de", size = 3990652, upload-time = "2026-04-08T01:56:29.095Z" },
+    { url = "https://files.pythonhosted.org/packages/36/5f/313586c3be5a2fbe87e4c9a254207b860155a8e1f3cca99f9910008e7d08/cryptography-46.0.7-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:8a469028a86f12eb7d2fe97162d0634026d92a21f3ae0ac87ed1c4a447886c83", size = 4279805, upload-time = "2026-04-08T01:56:30.928Z" },
+    { url = "https://files.pythonhosted.org/packages/69/33/60dfc4595f334a2082749673386a4d05e4f0cf4df8248e63b2c3437585f2/cryptography-46.0.7-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:9694078c5d44c157ef3162e3bf3946510b857df5a3955458381d1c7cfc143ddb", size = 4892883, upload-time = "2026-04-08T01:56:32.614Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/0b/333ddab4270c4f5b972f980adef4faa66951a4aaf646ca067af597f15563/cryptography-46.0.7-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:42a1e5f98abb6391717978baf9f90dc28a743b7d9be7f0751a6f56a75d14065b", size = 4459756, upload-time = "2026-04-08T01:56:34.306Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/14/633913398b43b75f1234834170947957c6b623d1701ffc7a9600da907e89/cryptography-46.0.7-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:91bbcb08347344f810cbe49065914fe048949648f6bd5c2519f34619142bbe85", size = 4410244, upload-time = "2026-04-08T01:56:35.977Z" },
+    { url = "https://files.pythonhosted.org/packages/10/f2/19ceb3b3dc14009373432af0c13f46aa08e3ce334ec6eff13492e1812ccd/cryptography-46.0.7-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:5d1c02a14ceb9148cc7816249f64f623fbfee39e8c03b3650d842ad3f34d637e", size = 4674868, upload-time = "2026-04-08T01:56:38.034Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/bb/a5c213c19ee94b15dfccc48f363738633a493812687f5567addbcbba9f6f/cryptography-46.0.7-cp311-abi3-win32.whl", hash = "sha256:d23c8ca48e44ee015cd0a54aeccdf9f09004eba9fc96f38c911011d9ff1bd457", size = 3026504, upload-time = "2026-04-08T01:56:39.666Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/02/7788f9fefa1d060ca68717c3901ae7fffa21ee087a90b7f23c7a603c32ae/cryptography-46.0.7-cp311-abi3-win_amd64.whl", hash = "sha256:397655da831414d165029da9bc483bed2fe0e75dde6a1523ec2fe63f3c46046b", size = 3488363, upload-time = "2026-04-08T01:56:41.893Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/56/15619b210e689c5403bb0540e4cb7dbf11a6bf42e483b7644e471a2812b3/cryptography-46.0.7-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:d151173275e1728cf7839aaa80c34fe550c04ddb27b34f48c232193df8db5842", size = 7119671, upload-time = "2026-04-08T01:56:44Z" },
+    { url = "https://files.pythonhosted.org/packages/74/66/e3ce040721b0b5599e175ba91ab08884c75928fbeb74597dd10ef13505d2/cryptography-46.0.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:db0f493b9181c7820c8134437eb8b0b4792085d37dbb24da050476ccb664e59c", size = 4268551, upload-time = "2026-04-08T01:56:46.071Z" },
+    { url = "https://files.pythonhosted.org/packages/03/11/5e395f961d6868269835dee1bafec6a1ac176505a167f68b7d8818431068/cryptography-46.0.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ebd6daf519b9f189f85c479427bbd6e9c9037862cf8fe89ee35503bd209ed902", size = 4408887, upload-time = "2026-04-08T01:56:47.718Z" },
+    { url = "https://files.pythonhosted.org/packages/40/53/8ed1cf4c3b9c8e611e7122fb56f1c32d09e1fff0f1d77e78d9ff7c82653e/cryptography-46.0.7-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:b7b412817be92117ec5ed95f880defe9cf18a832e8cafacf0a22337dc1981b4d", size = 4271354, upload-time = "2026-04-08T01:56:49.312Z" },
+    { url = "https://files.pythonhosted.org/packages/50/46/cf71e26025c2e767c5609162c866a78e8a2915bbcfa408b7ca495c6140c4/cryptography-46.0.7-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:fbfd0e5f273877695cb93baf14b185f4878128b250cc9f8e617ea0c025dfb022", size = 4905845, upload-time = "2026-04-08T01:56:50.916Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/ea/01276740375bac6249d0a971ebdf6b4dc9ead0ee0a34ef3b5a88c1a9b0d4/cryptography-46.0.7-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:ffca7aa1d00cf7d6469b988c581598f2259e46215e0140af408966a24cf086ce", size = 4444641, upload-time = "2026-04-08T01:56:52.882Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/4c/7d258f169ae71230f25d9f3d06caabcff8c3baf0978e2b7d65e0acac3827/cryptography-46.0.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:60627cf07e0d9274338521205899337c5d18249db56865f943cbe753aa96f40f", size = 3967749, upload-time = "2026-04-08T01:56:54.597Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/2a/2ea0767cad19e71b3530e4cad9605d0b5e338b6a1e72c37c9c1ceb86c333/cryptography-46.0.7-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:80406c3065e2c55d7f49a9550fe0c49b3f12e5bfff5dedb727e319e1afb9bf99", size = 4270942, upload-time = "2026-04-08T01:56:56.416Z" },
+    { url = "https://files.pythonhosted.org/packages/41/3d/fe14df95a83319af25717677e956567a105bb6ab25641acaa093db79975d/cryptography-46.0.7-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:c5b1ccd1239f48b7151a65bc6dd54bcfcc15e028c8ac126d3fada09db0e07ef1", size = 4871079, upload-time = "2026-04-08T01:56:58.31Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/59/4a479e0f36f8f378d397f4eab4c850b4ffb79a2f0d58704b8fa0703ddc11/cryptography-46.0.7-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:d5f7520159cd9c2154eb61eb67548ca05c5774d39e9c2c4339fd793fe7d097b2", size = 4443999, upload-time = "2026-04-08T01:57:00.508Z" },
+    { url = "https://files.pythonhosted.org/packages/28/17/b59a741645822ec6d04732b43c5d35e4ef58be7bfa84a81e5ae6f05a1d33/cryptography-46.0.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:fcd8eac50d9138c1d7fc53a653ba60a2bee81a505f9f8850b6b2888555a45d0e", size = 4399191, upload-time = "2026-04-08T01:57:02.654Z" },
+    { url = "https://files.pythonhosted.org/packages/59/6a/bb2e166d6d0e0955f1e9ff70f10ec4b2824c9cfcdb4da772c7dd69cc7d80/cryptography-46.0.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:65814c60f8cc400c63131584e3e1fad01235edba2614b61fbfbfa954082db0ee", size = 4655782, upload-time = "2026-04-08T01:57:04.592Z" },
+    { url = "https://files.pythonhosted.org/packages/95/b6/3da51d48415bcb63b00dc17c2eff3a651b7c4fed484308d0f19b30e8cb2c/cryptography-46.0.7-cp314-cp314t-win32.whl", hash = "sha256:fdd1736fed309b4300346f88f74cd120c27c56852c3838cab416e7a166f67298", size = 3002227, upload-time = "2026-04-08T01:57:06.91Z" },
+    { url = "https://files.pythonhosted.org/packages/32/a8/9f0e4ed57ec9cebe506e58db11ae472972ecb0c659e4d52bbaee80ca340a/cryptography-46.0.7-cp314-cp314t-win_amd64.whl", hash = "sha256:e06acf3c99be55aa3b516397fe42f5855597f430add9c17fa46bf2e0fb34c9bb", size = 3475332, upload-time = "2026-04-08T01:57:08.807Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/7f/cd42fc3614386bc0c12f0cb3c4ae1fc2bbca5c9662dfed031514911d513d/cryptography-46.0.7-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:462ad5cb1c148a22b2e3bcc5ad52504dff325d17daf5df8d88c17dda1f75f2a4", size = 7165618, upload-time = "2026-04-08T01:57:10.645Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/d0/36a49f0262d2319139d2829f773f1b97ef8aef7f97e6e5bd21455e5a8fb5/cryptography-46.0.7-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:84d4cced91f0f159a7ddacad249cc077e63195c36aac40b4150e7a57e84fffe7", size = 4270628, upload-time = "2026-04-08T01:57:12.885Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/6c/1a42450f464dda6ffbe578a911f773e54dd48c10f9895a23a7e88b3e7db5/cryptography-46.0.7-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:128c5edfe5e5938b86b03941e94fac9ee793a94452ad1365c9fc3f4f62216832", size = 4415405, upload-time = "2026-04-08T01:57:14.923Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/92/4ed714dbe93a066dc1f4b4581a464d2d7dbec9046f7c8b7016f5286329e2/cryptography-46.0.7-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:5e51be372b26ef4ba3de3c167cd3d1022934bc838ae9eaad7e644986d2a3d163", size = 4272715, upload-time = "2026-04-08T01:57:16.638Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/e6/a26b84096eddd51494bba19111f8fffe976f6a09f132706f8f1bf03f51f7/cryptography-46.0.7-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:cdf1a610ef82abb396451862739e3fc93b071c844399e15b90726ef7470eeaf2", size = 4918400, upload-time = "2026-04-08T01:57:19.021Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/08/ffd537b605568a148543ac3c2b239708ae0bd635064bab41359252ef88ed/cryptography-46.0.7-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:1d25aee46d0c6f1a501adcddb2d2fee4b979381346a78558ed13e50aa8a59067", size = 4450634, upload-time = "2026-04-08T01:57:21.185Z" },
+    { url = "https://files.pythonhosted.org/packages/16/01/0cd51dd86ab5b9befe0d031e276510491976c3a80e9f6e31810cce46c4ad/cryptography-46.0.7-cp38-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:cdfbe22376065ffcf8be74dc9a909f032df19bc58a699456a21712d6e5eabfd0", size = 3985233, upload-time = "2026-04-08T01:57:22.862Z" },
+    { url = "https://files.pythonhosted.org/packages/92/49/819d6ed3a7d9349c2939f81b500a738cb733ab62fbecdbc1e38e83d45e12/cryptography-46.0.7-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:abad9dac36cbf55de6eb49badd4016806b3165d396f64925bf2999bcb67837ba", size = 4271955, upload-time = "2026-04-08T01:57:24.814Z" },
+    { url = "https://files.pythonhosted.org/packages/80/07/ad9b3c56ebb95ed2473d46df0847357e01583f4c52a85754d1a55e29e4d0/cryptography-46.0.7-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:935ce7e3cfdb53e3536119a542b839bb94ec1ad081013e9ab9b7cfd478b05006", size = 4879888, upload-time = "2026-04-08T01:57:26.88Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/c7/201d3d58f30c4c2bdbe9b03844c291feb77c20511cc3586daf7edc12a47b/cryptography-46.0.7-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:35719dc79d4730d30f1c2b6474bd6acda36ae2dfae1e3c16f2051f215df33ce0", size = 4449961, upload-time = "2026-04-08T01:57:29.068Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/ef/649750cbf96f3033c3c976e112265c33906f8e462291a33d77f90356548c/cryptography-46.0.7-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:7bbc6ccf49d05ac8f7d7b5e2e2c33830d4fe2061def88210a126d130d7f71a85", size = 4401696, upload-time = "2026-04-08T01:57:31.029Z" },
+    { url = "https://files.pythonhosted.org/packages/41/52/a8908dcb1a389a459a29008c29966c1d552588d4ae6d43f3a1a4512e0ebe/cryptography-46.0.7-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a1529d614f44b863a7b480c6d000fe93b59acee9c82ffa027cfadc77521a9f5e", size = 4664256, upload-time = "2026-04-08T01:57:33.144Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/fa/f0ab06238e899cc3fb332623f337a7364f36f4bb3f2534c2bb95a35b132c/cryptography-46.0.7-cp38-abi3-win32.whl", hash = "sha256:f247c8c1a1fb45e12586afbb436ef21ff1e80670b2861a90353d9b025583d246", size = 3013001, upload-time = "2026-04-08T01:57:34.933Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/f1/00ce3bde3ca542d1acd8f8cfa38e446840945aa6363f9b74746394b14127/cryptography-46.0.7-cp38-abi3-win_amd64.whl", hash = "sha256:506c4ff91eff4f82bdac7633318a526b1d1309fc07ca76a3ad182cb5b686d6d3", size = 3472985, upload-time = "2026-04-08T01:57:36.714Z" },
+]
+
+[[package]]
 name = "deprecated"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -469,6 +540,27 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/0a/f9/5c5bcce82a7997cc0eb8c47b7800f862f6b56adc40486ed246e5010d443b/fastapi-0.119.0.tar.gz", hash = "sha256:451082403a2c1f0b99c6bd57c09110ed5463856804c8078d38e5a1f1035dbbb7", size = 336756, upload-time = "2025-10-11T17:13:40.53Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ce/70/584c4d7cad80f5e833715c0a29962d7c93b4d18eed522a02981a6d1b6ee5/fastapi-0.119.0-py3-none-any.whl", hash = "sha256:90a2e49ed19515320abb864df570dd766be0662c5d577688f1600170f7f73cf2", size = 107095, upload-time = "2025-10-11T17:13:39.048Z" },
+]
+
+[[package]]
+name = "fastapi-mail"
+version = "1.5.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiosmtplib" },
+    { name = "blinker" },
+    { name = "cryptography" },
+    { name = "email-validator" },
+    { name = "jinja2" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "regex" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/26/05/c50b2530b6fae758d712963a33b1af37a114ee1c56b02918bfc005d10f88/fastapi_mail-1.5.8.tar.gz", hash = "sha256:4758a8e236670b594387992e98dce219a19495ffbe801c71344c1819c1e3e938", size = 13469, upload-time = "2025-11-04T07:02:48.17Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/a1/d18b2067680556ba1441a29fc06d9f3a7952c6e731b8eac84c08638b5517/fastapi_mail-1.5.8-py3-none-any.whl", hash = "sha256:11267795511b5ee5dd05712195c6bcb969686fb29d5689704e2c04bd5a187c41", size = 15311, upload-time = "2025-11-04T07:02:46.878Z" },
 ]
 
 [[package]]
@@ -2020,6 +2112,70 @@ wheels = [
 ]
 
 [[package]]
+name = "regex"
+version = "2025.11.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cc/a9/546676f25e573a4cf00fe8e119b78a37b6a8fe2dc95cda877b30889c9c45/regex-2025.11.3.tar.gz", hash = "sha256:1fedc720f9bb2494ce31a58a1631f9c82df6a09b49c19517ea5cc280b4541e01", size = 414669, upload-time = "2025-11-03T21:34:22.089Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/a7/dda24ebd49da46a197436ad96378f17df30ceb40e52e859fc42cac45b850/regex-2025.11.3-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:c1e448051717a334891f2b9a620fe36776ebf3dd8ec46a0b877c8ae69575feb4", size = 489081, upload-time = "2025-11-03T21:31:55.9Z" },
+    { url = "https://files.pythonhosted.org/packages/19/22/af2dc751aacf88089836aa088a1a11c4f21a04707eb1b0478e8e8fb32847/regex-2025.11.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:9b5aca4d5dfd7fbfbfbdaf44850fcc7709a01146a797536a8f84952e940cca76", size = 291123, upload-time = "2025-11-03T21:31:57.758Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/88/1a3ea5672f4b0a84802ee9891b86743438e7c04eb0b8f8c4e16a42375327/regex-2025.11.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:04d2765516395cf7dda331a244a3282c0f5ae96075f728629287dfa6f76ba70a", size = 288814, upload-time = "2025-11-03T21:32:01.12Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/8c/f5987895bf42b8ddeea1b315c9fedcfe07cadee28b9c98cf50d00adcb14d/regex-2025.11.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5d9903ca42bfeec4cebedba8022a7c97ad2aab22e09573ce9976ba01b65e4361", size = 798592, upload-time = "2025-11-03T21:32:03.006Z" },
+    { url = "https://files.pythonhosted.org/packages/99/2a/6591ebeede78203fa77ee46a1c36649e02df9eaa77a033d1ccdf2fcd5d4e/regex-2025.11.3-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:639431bdc89d6429f6721625e8129413980ccd62e9d3f496be618a41d205f160", size = 864122, upload-time = "2025-11-03T21:32:04.553Z" },
+    { url = "https://files.pythonhosted.org/packages/94/d6/be32a87cf28cf8ed064ff281cfbd49aefd90242a83e4b08b5a86b38e8eb4/regex-2025.11.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f117efad42068f9715677c8523ed2be1518116d1c49b1dd17987716695181efe", size = 912272, upload-time = "2025-11-03T21:32:06.148Z" },
+    { url = "https://files.pythonhosted.org/packages/62/11/9bcef2d1445665b180ac7f230406ad80671f0fc2a6ffb93493b5dd8cd64c/regex-2025.11.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4aecb6f461316adf9f1f0f6a4a1a3d79e045f9b71ec76055a791affa3b285850", size = 803497, upload-time = "2025-11-03T21:32:08.162Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/a7/da0dc273d57f560399aa16d8a68ae7f9b57679476fc7ace46501d455fe84/regex-2025.11.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:3b3a5f320136873cc5561098dfab677eea139521cb9a9e8db98b7e64aef44cbc", size = 787892, upload-time = "2025-11-03T21:32:09.769Z" },
+    { url = "https://files.pythonhosted.org/packages/da/4b/732a0c5a9736a0b8d6d720d4945a2f1e6f38f87f48f3173559f53e8d5d82/regex-2025.11.3-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:75fa6f0056e7efb1f42a1c34e58be24072cb9e61a601340cc1196ae92326a4f9", size = 858462, upload-time = "2025-11-03T21:32:11.769Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/f5/a2a03df27dc4c2d0c769220f5110ba8c4084b0bfa9ab0f9b4fcfa3d2b0fc/regex-2025.11.3-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:dbe6095001465294f13f1adcd3311e50dd84e5a71525f20a10bd16689c61ce0b", size = 850528, upload-time = "2025-11-03T21:32:13.906Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/09/e1cd5bee3841c7f6eb37d95ca91cdee7100b8f88b81e41c2ef426910891a/regex-2025.11.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:454d9b4ae7881afbc25015b8627c16d88a597479b9dea82b8c6e7e2e07240dc7", size = 789866, upload-time = "2025-11-03T21:32:15.748Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/51/702f5ea74e2a9c13d855a6a85b7f80c30f9e72a95493260193c07f3f8d74/regex-2025.11.3-cp313-cp313-win32.whl", hash = "sha256:28ba4d69171fc6e9896337d4fc63a43660002b7da53fc15ac992abcf3410917c", size = 266189, upload-time = "2025-11-03T21:32:17.493Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/00/6e29bb314e271a743170e53649db0fdb8e8ff0b64b4f425f5602f4eb9014/regex-2025.11.3-cp313-cp313-win_amd64.whl", hash = "sha256:bac4200befe50c670c405dc33af26dad5a3b6b255dd6c000d92fe4629f9ed6a5", size = 277054, upload-time = "2025-11-03T21:32:19.042Z" },
+    { url = "https://files.pythonhosted.org/packages/25/f1/b156ff9f2ec9ac441710764dda95e4edaf5f36aca48246d1eea3f1fd96ec/regex-2025.11.3-cp313-cp313-win_arm64.whl", hash = "sha256:2292cd5a90dab247f9abe892ac584cb24f0f54680c73fcb4a7493c66c2bf2467", size = 270325, upload-time = "2025-11-03T21:32:21.338Z" },
+    { url = "https://files.pythonhosted.org/packages/20/28/fd0c63357caefe5680b8ea052131acbd7f456893b69cc2a90cc3e0dc90d4/regex-2025.11.3-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:1eb1ebf6822b756c723e09f5186473d93236c06c579d2cc0671a722d2ab14281", size = 491984, upload-time = "2025-11-03T21:32:23.466Z" },
+    { url = "https://files.pythonhosted.org/packages/df/ec/7014c15626ab46b902b3bcc4b28a7bae46d8f281fc7ea9c95e22fcaaa917/regex-2025.11.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:1e00ec2970aab10dc5db34af535f21fcf32b4a31d99e34963419636e2f85ae39", size = 292673, upload-time = "2025-11-03T21:32:25.034Z" },
+    { url = "https://files.pythonhosted.org/packages/23/ab/3b952ff7239f20d05f1f99e9e20188513905f218c81d52fb5e78d2bf7634/regex-2025.11.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:a4cb042b615245d5ff9b3794f56be4138b5adc35a4166014d31d1814744148c7", size = 291029, upload-time = "2025-11-03T21:32:26.528Z" },
+    { url = "https://files.pythonhosted.org/packages/21/7e/3dc2749fc684f455f162dcafb8a187b559e2614f3826877d3844a131f37b/regex-2025.11.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:44f264d4bf02f3176467d90b294d59bf1db9fe53c141ff772f27a8b456b2a9ed", size = 807437, upload-time = "2025-11-03T21:32:28.363Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/0b/d529a85ab349c6a25d1ca783235b6e3eedf187247eab536797021f7126c6/regex-2025.11.3-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7be0277469bf3bd7a34a9c57c1b6a724532a0d235cd0dc4e7f4316f982c28b19", size = 873368, upload-time = "2025-11-03T21:32:30.4Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/18/2d868155f8c9e3e9d8f9e10c64e9a9f496bb8f7e037a88a8bed26b435af6/regex-2025.11.3-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:0d31e08426ff4b5b650f68839f5af51a92a5b51abd8554a60c2fbc7c71f25d0b", size = 914921, upload-time = "2025-11-03T21:32:32.123Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/71/9d72ff0f354fa783fe2ba913c8734c3b433b86406117a8db4ea2bf1c7a2f/regex-2025.11.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e43586ce5bd28f9f285a6e729466841368c4a0353f6fd08d4ce4630843d3648a", size = 812708, upload-time = "2025-11-03T21:32:34.305Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/19/ce4bf7f5575c97f82b6e804ffb5c4e940c62609ab2a0d9538d47a7fdf7d4/regex-2025.11.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:0f9397d561a4c16829d4e6ff75202c1c08b68a3bdbfe29dbfcdb31c9830907c6", size = 795472, upload-time = "2025-11-03T21:32:36.364Z" },
+    { url = "https://files.pythonhosted.org/packages/03/86/fd1063a176ffb7b2315f9a1b08d17b18118b28d9df163132615b835a26ee/regex-2025.11.3-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:dd16e78eb18ffdb25ee33a0682d17912e8cc8a770e885aeee95020046128f1ce", size = 868341, upload-time = "2025-11-03T21:32:38.042Z" },
+    { url = "https://files.pythonhosted.org/packages/12/43/103fb2e9811205e7386366501bc866a164a0430c79dd59eac886a2822950/regex-2025.11.3-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:ffcca5b9efe948ba0661e9df0fa50d2bc4b097c70b9810212d6b62f05d83b2dd", size = 854666, upload-time = "2025-11-03T21:32:40.079Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/22/e392e53f3869b75804762c7c848bd2dd2abf2b70fb0e526f58724638bd35/regex-2025.11.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:c56b4d162ca2b43318ac671c65bd4d563e841a694ac70e1a976ac38fcf4ca1d2", size = 799473, upload-time = "2025-11-03T21:32:42.148Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/f9/8bd6b656592f925b6845fcbb4d57603a3ac2fb2373344ffa1ed70aa6820a/regex-2025.11.3-cp313-cp313t-win32.whl", hash = "sha256:9ddc42e68114e161e51e272f667d640f97e84a2b9ef14b7477c53aac20c2d59a", size = 268792, upload-time = "2025-11-03T21:32:44.13Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/87/0e7d603467775ff65cd2aeabf1b5b50cc1c3708556a8b849a2fa4dd1542b/regex-2025.11.3-cp313-cp313t-win_amd64.whl", hash = "sha256:7a7c7fdf755032ffdd72c77e3d8096bdcb0eb92e89e17571a196f03d88b11b3c", size = 280214, upload-time = "2025-11-03T21:32:45.853Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/d0/2afc6f8e94e2b64bfb738a7c2b6387ac1699f09f032d363ed9447fd2bb57/regex-2025.11.3-cp313-cp313t-win_arm64.whl", hash = "sha256:df9eb838c44f570283712e7cff14c16329a9f0fb19ca492d21d4b7528ee6821e", size = 271469, upload-time = "2025-11-03T21:32:48.026Z" },
+    { url = "https://files.pythonhosted.org/packages/31/e9/f6e13de7e0983837f7b6d238ad9458800a874bf37c264f7923e63409944c/regex-2025.11.3-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:9697a52e57576c83139d7c6f213d64485d3df5bf84807c35fa409e6c970801c6", size = 489089, upload-time = "2025-11-03T21:32:50.027Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/5c/261f4a262f1fa65141c1b74b255988bd2fa020cc599e53b080667d591cfc/regex-2025.11.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:e18bc3f73bd41243c9b38a6d9f2366cd0e0137a9aebe2d8ff76c5b67d4c0a3f4", size = 291059, upload-time = "2025-11-03T21:32:51.682Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/57/f14eeb7f072b0e9a5a090d1712741fd8f214ec193dba773cf5410108bb7d/regex-2025.11.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:61a08bcb0ec14ff4e0ed2044aad948d0659604f824cbd50b55e30b0ec6f09c73", size = 288900, upload-time = "2025-11-03T21:32:53.569Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/6b/1d650c45e99a9b327586739d926a1cd4e94666b1bd4af90428b36af66dc7/regex-2025.11.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c9c30003b9347c24bcc210958c5d167b9e4f9be786cb380a7d32f14f9b84674f", size = 799010, upload-time = "2025-11-03T21:32:55.222Z" },
+    { url = "https://files.pythonhosted.org/packages/99/ee/d66dcbc6b628ce4e3f7f0cbbb84603aa2fc0ffc878babc857726b8aab2e9/regex-2025.11.3-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:4e1e592789704459900728d88d41a46fe3969b82ab62945560a31732ffc19a6d", size = 864893, upload-time = "2025-11-03T21:32:57.239Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/2d/f238229f1caba7ac87a6c4153d79947fb0261415827ae0f77c304260c7d3/regex-2025.11.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6538241f45eb5a25aa575dbba1069ad786f68a4f2773a29a2bd3dd1f9de787be", size = 911522, upload-time = "2025-11-03T21:32:59.274Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/3d/22a4eaba214a917c80e04f6025d26143690f0419511e0116508e24b11c9b/regex-2025.11.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bce22519c989bb72a7e6b36a199384c53db7722fe669ba891da75907fe3587db", size = 803272, upload-time = "2025-11-03T21:33:01.393Z" },
+    { url = "https://files.pythonhosted.org/packages/84/b1/03188f634a409353a84b5ef49754b97dbcc0c0f6fd6c8ede505a8960a0a4/regex-2025.11.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:66d559b21d3640203ab9075797a55165d79017520685fb407b9234d72ab63c62", size = 787958, upload-time = "2025-11-03T21:33:03.379Z" },
+    { url = "https://files.pythonhosted.org/packages/99/6a/27d072f7fbf6fadd59c64d210305e1ff865cc3b78b526fd147db768c553b/regex-2025.11.3-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:669dcfb2e38f9e8c69507bace46f4889e3abbfd9b0c29719202883c0a603598f", size = 859289, upload-time = "2025-11-03T21:33:05.374Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/70/1b3878f648e0b6abe023172dacb02157e685564853cc363d9961bcccde4e/regex-2025.11.3-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:32f74f35ff0f25a5021373ac61442edcb150731fbaa28286bbc8bb1582c89d02", size = 850026, upload-time = "2025-11-03T21:33:07.131Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/d5/68e25559b526b8baab8e66839304ede68ff6727237a47727d240006bd0ff/regex-2025.11.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e6c7a21dffba883234baefe91bc3388e629779582038f75d2a5be918e250f0ed", size = 789499, upload-time = "2025-11-03T21:33:09.141Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/df/43971264857140a350910d4e33df725e8c94dd9dee8d2e4729fa0d63d49e/regex-2025.11.3-cp314-cp314-win32.whl", hash = "sha256:795ea137b1d809eb6836b43748b12634291c0ed55ad50a7d72d21edf1cd565c4", size = 271604, upload-time = "2025-11-03T21:33:10.9Z" },
+    { url = "https://files.pythonhosted.org/packages/01/6f/9711b57dc6894a55faf80a4c1b5aa4f8649805cb9c7aef46f7d27e2b9206/regex-2025.11.3-cp314-cp314-win_amd64.whl", hash = "sha256:9f95fbaa0ee1610ec0fc6b26668e9917a582ba80c52cc6d9ada15e30aa9ab9ad", size = 280320, upload-time = "2025-11-03T21:33:12.572Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/7e/f6eaa207d4377481f5e1775cdeb5a443b5a59b392d0065f3417d31d80f87/regex-2025.11.3-cp314-cp314-win_arm64.whl", hash = "sha256:dfec44d532be4c07088c3de2876130ff0fbeeacaa89a137decbbb5f665855a0f", size = 273372, upload-time = "2025-11-03T21:33:14.219Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/06/49b198550ee0f5e4184271cee87ba4dfd9692c91ec55289e6282f0f86ccf/regex-2025.11.3-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:ba0d8a5d7f04f73ee7d01d974d47c5834f8a1b0224390e4fe7c12a3a92a78ecc", size = 491985, upload-time = "2025-11-03T21:33:16.555Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/bf/abdafade008f0b1c9da10d934034cb670432d6cf6cbe38bbb53a1cfd6cf8/regex-2025.11.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:442d86cf1cfe4faabf97db7d901ef58347efd004934da045c745e7b5bd57ac49", size = 292669, upload-time = "2025-11-03T21:33:18.32Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/ef/0c357bb8edbd2ad8e273fcb9e1761bc37b8acbc6e1be050bebd6475f19c1/regex-2025.11.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:fd0a5e563c756de210bb964789b5abe4f114dacae9104a47e1a649b910361536", size = 291030, upload-time = "2025-11-03T21:33:20.048Z" },
+    { url = "https://files.pythonhosted.org/packages/79/06/edbb67257596649b8fb088d6aeacbcb248ac195714b18a65e018bf4c0b50/regex-2025.11.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bf3490bcbb985a1ae97b2ce9ad1c0f06a852d5b19dde9b07bdf25bf224248c95", size = 807674, upload-time = "2025-11-03T21:33:21.797Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/d9/ad4deccfce0ea336296bd087f1a191543bb99ee1c53093dcd4c64d951d00/regex-2025.11.3-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:3809988f0a8b8c9dcc0f92478d6501fac7200b9ec56aecf0ec21f4a2ec4b6009", size = 873451, upload-time = "2025-11-03T21:33:23.741Z" },
+    { url = "https://files.pythonhosted.org/packages/13/75/a55a4724c56ef13e3e04acaab29df26582f6978c000ac9cd6810ad1f341f/regex-2025.11.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f4ff94e58e84aedb9c9fce66d4ef9f27a190285b451420f297c9a09f2b9abee9", size = 914980, upload-time = "2025-11-03T21:33:25.999Z" },
+    { url = "https://files.pythonhosted.org/packages/67/1e/a1657ee15bd9116f70d4a530c736983eed997b361e20ecd8f5ca3759d5c5/regex-2025.11.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7eb542fd347ce61e1321b0a6b945d5701528dca0cd9759c2e3bb8bd57e47964d", size = 812852, upload-time = "2025-11-03T21:33:27.852Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/6f/f7516dde5506a588a561d296b2d0044839de06035bb486b326065b4c101e/regex-2025.11.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d6c2d5919075a1f2e413c00b056ea0c2f065b3f5fe83c3d07d325ab92dce51d6", size = 795566, upload-time = "2025-11-03T21:33:32.364Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/dd/3d10b9e170cc16fb34cb2cef91513cf3df65f440b3366030631b2984a264/regex-2025.11.3-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:3f8bf11a4827cc7ce5a53d4ef6cddd5ad25595d3c1435ef08f76825851343154", size = 868463, upload-time = "2025-11-03T21:33:34.459Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/8e/935e6beff1695aa9085ff83195daccd72acc82c81793df480f34569330de/regex-2025.11.3-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:22c12d837298651e5550ac1d964e4ff57c3f56965fc1812c90c9fb2028eaf267", size = 854694, upload-time = "2025-11-03T21:33:36.793Z" },
+    { url = "https://files.pythonhosted.org/packages/92/12/10650181a040978b2f5720a6a74d44f841371a3d984c2083fc1752e4acf6/regex-2025.11.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:62ba394a3dda9ad41c7c780f60f6e4a70988741415ae96f6d1bf6c239cf01379", size = 799691, upload-time = "2025-11-03T21:33:39.079Z" },
+    { url = "https://files.pythonhosted.org/packages/67/90/8f37138181c9a7690e7e4cb388debbd389342db3c7381d636d2875940752/regex-2025.11.3-cp314-cp314t-win32.whl", hash = "sha256:4bf146dca15cdd53224a1bf46d628bd7590e4a07fbb69e720d561aea43a32b38", size = 274583, upload-time = "2025-11-03T21:33:41.302Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/cd/867f5ec442d56beb56f5f854f40abcfc75e11d10b11fdb1869dd39c63aaf/regex-2025.11.3-cp314-cp314t-win_amd64.whl", hash = "sha256:adad1a1bcf1c9e76346e091d22d23ac54ef28e1365117d99521631078dfec9de", size = 284286, upload-time = "2025-11-03T21:33:43.324Z" },
+    { url = "https://files.pythonhosted.org/packages/20/31/32c0c4610cbc070362bf1d2e4ea86d1ea29014d400a6d6c2486fcfd57766/regex-2025.11.3-cp314-cp314t-win_arm64.whl", hash = "sha256:c54f768482cef41e219720013cd05933b6f971d9562544d691c68699bf2b6801", size = 274741, upload-time = "2025-11-03T21:33:45.557Z" },
+]
+
+[[package]]
 name = "requests"
 version = "2.32.5"
 source = { registry = "https://pypi.org/simple" }
@@ -2347,6 +2503,7 @@ dependencies = [
     { name = "docutils" },
     { name = "durationpy" },
     { name = "fastapi" },
+    { name = "fastapi-mail" },
     { name = "filelock" },
     { name = "flatbuffers" },
     { name = "fsspec" },
@@ -2503,6 +2660,7 @@ requires-dist = [
     { name = "docutils", specifier = "==0.22.3" },
     { name = "durationpy", specifier = "==0.10" },
     { name = "fastapi", specifier = "==0.119.0" },
+    { name = "fastapi-mail", specifier = ">=1.5.8" },
     { name = "filelock", specifier = "==3.20.0" },
     { name = "flatbuffers", specifier = "==25.9.23" },
     { name = "fsspec", specifier = "==2025.9.0" },

--- a/docker/local/docker-compose.yml
+++ b/docker/local/docker-compose.yml
@@ -39,10 +39,37 @@ services:
     networks:
       - studybuddy-local-network
 
+  redis:
+    image: redis:7-alpine
+    container_name: studybuddy-local-redis
+    restart: unless-stopped
+    volumes:
+      - redis_local_data:/data
+    ports:
+      - "6379:6379"
+    networks:
+      - studybuddy-local-network
+
+  mailpit:
+    image: axllent/mailpit:latest
+    container_name: studybuddy-local-mailpit
+    restart: unless-stopped
+    ports:
+      - "1025:1025"   # SMTP
+      - "8025:8025"   # Web UI
+    environment:
+      MP_MAX_MESSAGES: 5000
+      MP_SMTP_AUTH_ACCEPT_ANY: 1
+      MP_SMTP_AUTH_ALLOW_INSECURE: 1
+    networks:
+      - studybuddy-local-network
+
 volumes:
   postgres_local_data:
     driver: local
   weaviate_local_data:
+    driver: local
+  redis_local_data:
     driver: local
 
 networks:

--- a/docs/adr/0001-jwt-storage-strategy.md
+++ b/docs/adr/0001-jwt-storage-strategy.md
@@ -1,0 +1,76 @@
+# ADR-0001: JWT Storage Strategy
+
+**Status:** Accepted
+**Date:** 2026-05-18
+**Issue:** AUTH-15
+
+## Context
+
+Das Backend gibt nach erfolgreichem Login zwei Tokens aus:
+
+- **Access Token** (JWT, HS256, 30 min TTL) — wird bei jedem API-Call mitgeschickt
+- **Refresh Token** (opaque, 7 Tage TTL) — wird verwendet um neue Access Tokens auszustellen
+
+Aktuell werden beide als JSON-Body zurückgegeben (`TokenResponse`). Wo das Frontend (Next.js 16 SPA) sie speichert, ist noch nicht entschieden. Die Wahl bestimmt die Angriffsfläche für XSS und CSRF.
+
+### Threat Model
+
+- **XSS** — jede npm-Dependency, jedes user-generated Content Feld kann Schadcode injizieren. In einer modernen SPA mit dutzenden Dependencies ist XSS realistisch.
+- **CSRF** — Angreifer-Website triggert einen authentifizierten Request vom Browser des Opfers. Mit modernen Browser-Defaults (`SameSite=Lax`) und korrekter Cookie-Config gut zu mitigieren.
+
+### Optionen
+
+| Option | Beschreibung | XSS | CSRF |
+|---|---|---|---|
+| **A** | beide Tokens in `localStorage` | ❌ beide stehlbar via XSS, 7-Tage-Persistenz | ✅ kein Cookie-Flow |
+| **B** | beide Tokens in HttpOnly Cookies | ✅ JS hat keinen Zugriff | ⚠️ mitigierbar mit SameSite+CSRF-Token, aber erzwingt Cookie-Flow für jeden API-Call |
+| **C** | **Hybrid:** Refresh in HttpOnly Cookie, Access in Memory | ✅ Refresh sicher, Access nur 30-min XSS-Fenster | ✅ Cookie nur für `/auth/refresh`, Strict möglich |
+
+## Decision
+
+**Option C — Hybrid.**
+
+- **Refresh Token** → HttpOnly Cookie mit `Secure; SameSite=Strict; Path=/api/auth; Max-Age=604800`
+- **Access Token** → JavaScript Module-Variable im Frontend (nicht `localStorage`, nicht `sessionStorage`, nicht `useState`)
+
+> **Cookie-Path-Hinweis:** Der Cookie ist auf `/api/auth` gescoped (nicht nur `/api/auth/refresh`), damit er auch beim `POST /api/auth/logout` mitgeschickt wird. Dort muss das Backend ihn löschen können. Damit ist die CSRF-Angriffsfläche minimal größer als bei einem reinen `/refresh`-Scope — durch `SameSite=Strict` in Production aber weiterhin geschlossen.
+
+### Begründung
+
+1. Ein 7-Tage-Refresh-Token in `localStorage` ist unverteidigbar — jeder XSS-Treffer öffnet ein 7-Tage-Persistenz-Fenster für den Angreifer.
+2. Cookie-Flow für **jeden** API-Call (Option B) erzwingt CORS `allow_credentials=True` und CSRF-Token überall — die Komplexität bringt keinen Mehrwert gegenüber Bearer Tokens im Header für den Access Token.
+3. Der Refresh-Token-Cookie ist auf `Path=/auth/refresh` beschränkt — er wird nicht bei jedem Request mitgeschickt, sondern nur beim Refresh-Endpoint. Damit ist die CSRF-Angriffsfläche minimal.
+4. `SameSite=Strict` ist nutzbar, weil Frontend und Backend in Production unter derselben Parent-Domain liegen (`app.studybuddy.at` ↔ `api.studybuddy.at`).
+5. Access Token in Memory bedeutet: nach Tab-Close / Browser-Restart ist er weg. Beim nächsten App-Load wird via Silent Refresh ein neuer ausgestellt (Refresh Cookie wird automatisch mitgeschickt).
+
+## Consequences
+
+### Backend (`app/routes/auth.py`) — **umgesetzt**
+
+- `POST /auth/login` — Access Token im JSON-Body, Refresh Token als `Set-Cookie`
+- `POST /auth/setup` — analog
+- `POST /auth/refresh` — Refresh Token aus Cookie lesen (nicht aus Body/Query), Cookie rotieren
+- `POST /auth/logout` — Cookie löschen via `delete_cookie`; Access-Token-JTI denylisten ist offen → AUTH-11
+- `TokenResponse` Schema — `refresh_token` Feld entfernt (kommt nur noch via Cookie)
+- Cookie-Settings via `settings.REFRESH_COOKIE_*` in `app/core/config.py` (Dev-Defaults: `SameSite=lax`, `Secure=false`; in Production via `.env` auf `strict` und `true` setzen)
+- CORS-Config — `allow_credentials=True` bereits gesetzt in `main.py`
+
+### Frontend (Next.js 16, kommt mit AUTH-07)
+
+- Access Token in Module-Variable (z.B. `lib/auth/tokenStore.ts`), niemals Persistenz
+- `fetch`/`axios` mit `credentials: "include"` für `/auth/refresh` und `/auth/logout`
+- App-Load Hook: Silent Refresh vor erstem geschützten Request
+- 401-Interceptor: einmaliger Refresh-Versuch, dann Redirect auf `/login`
+- Login-Form: erhält Access Token aus Response Body, persistiert nichts selbst
+
+### Dev-Setup
+
+- Frontend `localhost:3000`, Backend `localhost:8000` — Cookie funktioniert mit `SameSite=Lax` im Dev (Same-Site via `localhost`)
+- In Production: `SameSite=Strict`, weil beide Subdomains der gleichen Site sind
+
+### Verbleibende Angriffsfläche
+
+- **CSRF auf `/auth/refresh`** falls `SameSite` jemals auf `Lax`/`None` gelockert wird (z.B. für mobile Clients) → CSRF-Token nachrüsten
+- **XSS-Diebstahl des Access Tokens** im 30-Minuten-Fenster → CSP-Header, Trusted Types, Dependency-Audits
+- **Subdomain-Takeover** auf `*.studybuddy.at` würde Cookie-Diebstahl trotz HttpOnly ermöglichen → DNS und Subdomain-Management dokumentieren
+- **Silent-Refresh-Race** beim App-Load → Loading-State, keine geschützten Requests vor erstem Refresh

--- a/docs/adr/0001-jwt-storage-strategy.md
+++ b/docs/adr/0001-jwt-storage-strategy.md
@@ -6,71 +6,71 @@
 
 ## Context
 
-Das Backend gibt nach erfolgreichem Login zwei Tokens aus:
+After login the backend issues two tokens:
 
-- **Access Token** (JWT, HS256, 30 min TTL) — wird bei jedem API-Call mitgeschickt
-- **Refresh Token** (opaque, 7 Tage TTL) — wird verwendet um neue Access Tokens auszustellen
+- **Access Token** (JWT, HS256, 30 min TTL) — sent with every API call
+- **Refresh Token** (opaque random string, 7 day TTL) — exchanged for new access tokens
 
-Aktuell werden beide als JSON-Body zurückgegeben (`TokenResponse`). Wo das Frontend (Next.js 16 SPA) sie speichert, ist noch nicht entschieden. Die Wahl bestimmt die Angriffsfläche für XSS und CSRF.
+The question: where does the frontend store them? The decision determines the XSS and CSRF attack surface.
 
 ### Threat Model
 
-- **XSS** — jede npm-Dependency, jedes user-generated Content Feld kann Schadcode injizieren. In einer modernen SPA mit dutzenden Dependencies ist XSS realistisch.
-- **CSRF** — Angreifer-Website triggert einen authentifizierten Request vom Browser des Opfers. Mit modernen Browser-Defaults (`SameSite=Lax`) und korrekter Cookie-Config gut zu mitigieren.
+- **XSS** — any npm dependency, any user-generated content field can inject malicious JS. In a modern SPA with dozens of dependencies, XSS is realistic.
+- **CSRF** — an attacker-controlled site triggers an authenticated request from the victim's browser. Mitigatable with `SameSite=Strict` cookies plus optional CSRF tokens.
 
-### Optionen
+### Options
 
-| Option | Beschreibung | XSS | CSRF |
+| Option | Description | XSS | CSRF |
 |---|---|---|---|
-| **A** | beide Tokens in `localStorage` | ❌ beide stehlbar via XSS, 7-Tage-Persistenz | ✅ kein Cookie-Flow |
-| **B** | beide Tokens in HttpOnly Cookies | ✅ JS hat keinen Zugriff | ⚠️ mitigierbar mit SameSite+CSRF-Token, aber erzwingt Cookie-Flow für jeden API-Call |
-| **C** | **Hybrid:** Refresh in HttpOnly Cookie, Access in Memory | ✅ Refresh sicher, Access nur 30-min XSS-Fenster | ✅ Cookie nur für `/auth/refresh`, Strict möglich |
+| **A** | both tokens in `localStorage` | ❌ both stealable via XSS, 7-day persistence | ✅ no cookie flow |
+| **B** | both tokens in HttpOnly cookies | ✅ JS has no access | ⚠️ mitigatable with SameSite+CSRF token but forces cookie flow on every API call |
+| **C** | **Hybrid:** refresh in HttpOnly cookie, access in memory | ✅ refresh safe, access only 30-min XSS window | ✅ cookie only on `/auth/*`, Strict possible |
 
 ## Decision
 
 **Option C — Hybrid.**
 
-- **Refresh Token** → HttpOnly Cookie mit `Secure; SameSite=Strict; Path=/api/auth; Max-Age=604800`
-- **Access Token** → JavaScript Module-Variable im Frontend (nicht `localStorage`, nicht `sessionStorage`, nicht `useState`)
+- **Refresh Token** → HttpOnly cookie with `Secure; SameSite=Strict; Path=/api/auth; Max-Age=604800`
+- **Access Token** → JavaScript module variable in the frontend (not `localStorage`, not `sessionStorage`, not `useState`)
 
-> **Cookie-Path-Hinweis:** Der Cookie ist auf `/api/auth` gescoped (nicht nur `/api/auth/refresh`), damit er auch beim `POST /api/auth/logout` mitgeschickt wird. Dort muss das Backend ihn löschen können. Damit ist die CSRF-Angriffsfläche minimal größer als bei einem reinen `/refresh`-Scope — durch `SameSite=Strict` in Production aber weiterhin geschlossen.
+> **Cookie path:** The cookie is scoped to `/api/auth` (not just `/api/auth/refresh`) so it's also sent on `POST /api/auth/logout` — the backend needs it there to delete and denylist. The CSRF surface is minimally larger than a strict `/refresh`-only scope but stays closed with `SameSite=Strict` in production.
 
-### Begründung
+### Rationale
 
-1. Ein 7-Tage-Refresh-Token in `localStorage` ist unverteidigbar — jeder XSS-Treffer öffnet ein 7-Tage-Persistenz-Fenster für den Angreifer.
-2. Cookie-Flow für **jeden** API-Call (Option B) erzwingt CORS `allow_credentials=True` und CSRF-Token überall — die Komplexität bringt keinen Mehrwert gegenüber Bearer Tokens im Header für den Access Token.
-3. Der Refresh-Token-Cookie ist auf `Path=/auth/refresh` beschränkt — er wird nicht bei jedem Request mitgeschickt, sondern nur beim Refresh-Endpoint. Damit ist die CSRF-Angriffsfläche minimal.
-4. `SameSite=Strict` ist nutzbar, weil Frontend und Backend in Production unter derselben Parent-Domain liegen (`app.studybuddy.at` ↔ `api.studybuddy.at`).
-5. Access Token in Memory bedeutet: nach Tab-Close / Browser-Restart ist er weg. Beim nächsten App-Load wird via Silent Refresh ein neuer ausgestellt (Refresh Cookie wird automatisch mitgeschickt).
+1. A 7-day refresh token in `localStorage` is indefensible — any XSS hit opens a 7-day persistence window.
+2. Cookies for **every** API call (Option B) forces CORS `allow_credentials=True` plus CSRF tokens everywhere — complexity without benefit over a Bearer header for the access token.
+3. The refresh cookie is restricted to `Path=/api/auth` — it's not sent on every request, only when refreshing or logging out. CSRF surface is minimal.
+4. `SameSite=Strict` is usable because frontend and backend share the same domain in production (`studybuddy.mojiverse.at`).
+5. Access token in memory: gone after tab close or reload. App load fires a silent refresh; the refresh cookie auto-restores the session.
 
 ## Consequences
 
-### Backend (`app/routes/auth.py`) — **umgesetzt**
+### Backend (`app/routes/auth.py`)
 
-- `POST /auth/login` — Access Token im JSON-Body, Refresh Token als `Set-Cookie`
-- `POST /auth/setup` — analog
-- `POST /auth/refresh` — Refresh Token aus Cookie lesen (nicht aus Body/Query), Cookie rotieren
-- `POST /auth/logout` — Cookie löschen via `delete_cookie`; Access-Token-JTI denylisten ist offen → AUTH-11
-- `TokenResponse` Schema — `refresh_token` Feld entfernt (kommt nur noch via Cookie)
-- Cookie-Settings via `settings.REFRESH_COOKIE_*` in `app/core/config.py` (Dev-Defaults: `SameSite=lax`, `Secure=false`; in Production via `.env` auf `strict` und `true` setzen)
-- CORS-Config — `allow_credentials=True` bereits gesetzt in `main.py`
+- `POST /auth/login` — access token in JSON body, refresh token as `Set-Cookie`
+- `POST /auth/setup` — same
+- `POST /auth/refresh` — reads refresh token from cookie (not body/query), rotates the cookie
+- `POST /auth/logout` — denylists access token JTI (AUTH-11), revokes refresh tokens in DB, clears the cookie
+- `TokenResponse` schema — no `refresh_token` field; it lives in the cookie
+- Cookie settings via `settings.REFRESH_COOKIE_*` in `app/core/config.py` — dev defaults: `SameSite=lax`, `Secure=false`; production overrides to `strict` and `true` via `.env`
+- CORS — `allow_credentials=True` set in `main.py`
 
-### Frontend (Next.js 16, kommt mit AUTH-07)
+### Frontend (Next.js 16)
 
-- Access Token in Module-Variable (z.B. `lib/auth/tokenStore.ts`), niemals Persistenz
-- `fetch`/`axios` mit `credentials: "include"` für `/auth/refresh` und `/auth/logout`
-- App-Load Hook: Silent Refresh vor erstem geschützten Request
-- 401-Interceptor: einmaliger Refresh-Versuch, dann Redirect auf `/login`
-- Login-Form: erhält Access Token aus Response Body, persistiert nichts selbst
+- Access token in `lib/auth/tokenStore.ts` module variable; never persisted
+- `fetch` with `credentials: "include"` on `/auth/refresh` and `/auth/logout`
+- App-load hook (`AuthProvider`) runs silent refresh before the first protected request
+- 401 interceptor: one refresh attempt, then redirect to `/login`
+- Login form: receives access token from response body; persists nothing itself
 
-### Dev-Setup
+### Dev Setup
 
-- Frontend `localhost:3000`, Backend `localhost:8000` — Cookie funktioniert mit `SameSite=Lax` im Dev (Same-Site via `localhost`)
-- In Production: `SameSite=Strict`, weil beide Subdomains der gleichen Site sind
+- Frontend `localhost:3000`, backend `localhost:8001` — cookie works with `SameSite=Lax` (both are same-site under `localhost`)
+- Production: `SameSite=Strict`, both apps on `studybuddy.mojiverse.at`
 
-### Verbleibende Angriffsfläche
+### Remaining Attack Surface
 
-- **CSRF auf `/auth/refresh`** falls `SameSite` jemals auf `Lax`/`None` gelockert wird (z.B. für mobile Clients) → CSRF-Token nachrüsten
-- **XSS-Diebstahl des Access Tokens** im 30-Minuten-Fenster → CSP-Header, Trusted Types, Dependency-Audits
-- **Subdomain-Takeover** auf `*.studybuddy.at` würde Cookie-Diebstahl trotz HttpOnly ermöglichen → DNS und Subdomain-Management dokumentieren
-- **Silent-Refresh-Race** beim App-Load → Loading-State, keine geschützten Requests vor erstem Refresh
+- **CSRF on `/auth/refresh`** if `SameSite` is ever relaxed to `Lax`/`None` (e.g. for mobile clients) → add a CSRF token
+- **XSS theft of the access token** within its 30-minute window → CSP headers, Trusted Types, dependency audits
+- **Subdomain takeover** would allow cookie theft despite HttpOnly → document DNS and subdomain management
+- **Silent-refresh race on app load** → loading state, no protected requests before the first refresh resolves

--- a/docs/local-testing-guide.md
+++ b/docs/local-testing-guide.md
@@ -1,0 +1,121 @@
+# Local Testing Guide
+
+How to run Study Buddy end-to-end on your machine — including the JWT auth flow with email verification.
+
+## Prerequisites
+
+- Docker + Docker Compose
+- [uv](https://docs.astral.sh/uv/) (backend package manager)
+- [Bun](https://bun.com/) (frontend package manager)
+- `openssl` (for generating `SECRET_KEY`)
+
+## 1. Environment Files
+
+### Backend
+
+```bash
+cp backend/.env-example backend/.env
+```
+
+Generate a real `SECRET_KEY`:
+
+```bash
+openssl rand -hex 32
+```
+
+Paste the output into `backend/.env` as `SECRET_KEY=...`. The default `DATABASE_URL` already points at the local Postgres container — change only if you want to hit staging.
+
+### Frontend
+
+`frontend/.env.local` already exists with `NEXT_PUBLIC_API_URL=http://localhost:8001`. No changes needed for local dev.
+
+### Docker (local infrastructure)
+
+```bash
+cp docker/local/.env-example docker/local/.env
+```
+
+The defaults work as-is.
+
+## 2. Infrastructure
+
+Start Postgres, Redis, Weaviate, and Mailpit:
+
+```bash
+cd backend
+make db-up
+```
+
+`db-up` runs `docker compose up -d` on the local compose file. Verify everything is healthy:
+
+```bash
+docker ps
+```
+
+## 3. Backend
+
+```bash
+cd backend
+make install            # uv sync — installs dependencies
+uv run alembic upgrade head   # apply database migrations
+make dev                # uvicorn on port 8001 with auto-reload
+```
+
+Verify:
+
+```bash
+curl http://localhost:8001/health
+# {"status":"healthy"}
+```
+
+## 4. Frontend
+
+In a new terminal:
+
+```bash
+cd frontend
+bun install
+bun dev                 # Next.js on port 3000
+```
+
+## 5. Service URLs
+
+| Service | URL |
+|---|---|
+| Frontend | http://localhost:3000 |
+| Backend | http://localhost:8001 |
+| Backend OpenAPI | http://localhost:8001/docs |
+| Mailpit UI | http://localhost:8025 |
+| Postgres | `localhost:5432` |
+| Redis | `localhost:6379` |
+| Weaviate | http://localhost:8100 |
+
+## 6. End-to-End Auth Flow
+
+1. Open http://localhost:3000/register
+2. Enter an `@edu.fh-joanneum.at` address (any address works locally — Mailpit catches it)
+3. Open http://localhost:8025 — the verify email is there
+4. Click **"Konto einrichten"** (or "Set up account") in the email
+5. Enter username + password (min 12 chars) → redirected to home
+6. Header avatar shows your initials → click → see role + **Logout**
+
+## 7. Common Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Backend fails to start with `SECRET_KEY must be at least 32 characters` | `.env` placeholder still in place | Generate with `openssl rand -hex 32` |
+| Frontend gets CORS errors on `/auth/refresh` | Backend not running or wrong port | Check `make dev` is up on 8001 |
+| No email arrives in Mailpit | Mailpit container down | `docker ps` — restart with `make db-up` |
+| Login succeeds but `/me` returns 401 | Stale cookie from previous run | Clear cookies for `localhost:8001` |
+| Database errors after pulling code | New migrations not applied | `uv run alembic upgrade head` |
+
+## 8. Useful Make Targets
+
+```bash
+make dev          # start backend with auto-reload (port 8001)
+make db-up        # start local docker services
+make db-down      # stop local docker services
+make db-reset     # destroy volumes and recreate everything
+make test         # smoke-check that packages import and /health responds
+make clean        # remove __pycache__ etc.
+```

--- a/frontend/messages/de.json
+++ b/frontend/messages/de.json
@@ -143,6 +143,15 @@
       "passwordMinLength": "Passwort muss mindestens 12 Zeichen lang sein",
       "usernameRequired": "Benutzername ist erforderlich",
       "usernameMinLength": "Benutzername muss mindestens 3 Zeichen lang sein"
+    },
+    "menu": {
+      "signedInAs": "Angemeldet als",
+      "role": "Rolle",
+      "logout": "Abmelden",
+      "loggingOut": "Wird abgemeldet..."
+    },
+    "guard": {
+      "loading": "Lade..."
     }
   }
 }

--- a/frontend/messages/de.json
+++ b/frontend/messages/de.json
@@ -91,5 +91,58 @@
     "light": "Hell",
     "dark": "Dunkel",
     "system": "System"
+  },
+  "auth": {
+    "appName": "Study Buddy",
+    "tagline": "Lernunterlagen der FH Joanneum",
+    "login": {
+      "title": "Anmelden",
+      "subtitle": "Willkommen zurück",
+      "emailLabel": "E-Mail",
+      "emailPlaceholder": "vorname.nachname@edu.fh-joanneum.at",
+      "passwordLabel": "Passwort",
+      "passwordPlaceholder": "Dein Passwort",
+      "submit": "Anmelden",
+      "submitting": "Wird angemeldet...",
+      "noAccount": "Noch kein Konto?",
+      "registerLink": "Registrieren",
+      "errorTitle": "Anmeldung fehlgeschlagen"
+    },
+    "register": {
+      "title": "Registrieren",
+      "subtitle": "Erstelle ein Konto mit deiner FH-Joanneum-E-Mail",
+      "emailLabel": "E-Mail",
+      "emailPlaceholder": "vorname.nachname@edu.fh-joanneum.at",
+      "submit": "Registrieren",
+      "submitting": "Wird gesendet...",
+      "haveAccount": "Bereits ein Konto?",
+      "loginLink": "Anmelden",
+      "errorTitle": "Registrierung fehlgeschlagen",
+      "successTitle": "Prüfe deine E-Mails",
+      "successMessage": "Wir haben dir einen Bestätigungslink an {email} geschickt. Klicke auf den Link, um dein Konto einzurichten."
+    },
+    "setup": {
+      "title": "Konto einrichten",
+      "subtitle": "Wähle einen Benutzernamen und ein Passwort",
+      "usernameLabel": "Benutzername",
+      "usernamePlaceholder": "max.mustermann",
+      "passwordLabel": "Passwort",
+      "passwordPlaceholder": "Mindestens 12 Zeichen",
+      "passwordConfirmLabel": "Passwort bestätigen",
+      "submit": "Konto erstellen",
+      "submitting": "Wird erstellt...",
+      "errorTitle": "Einrichtung fehlgeschlagen",
+      "missingToken": "Kein Bestätigungstoken gefunden. Bitte verwende den Link aus deiner E-Mail.",
+      "passwordMismatch": "Passwörter stimmen nicht überein"
+    },
+    "validation": {
+      "emailRequired": "E-Mail ist erforderlich",
+      "emailInvalid": "Ungültige E-Mail-Adresse",
+      "emailDomain": "Nur @edu.fh-joanneum.at-Adressen erlaubt",
+      "passwordRequired": "Passwort ist erforderlich",
+      "passwordMinLength": "Passwort muss mindestens 12 Zeichen lang sein",
+      "usernameRequired": "Benutzername ist erforderlich",
+      "usernameMinLength": "Benutzername muss mindestens 3 Zeichen lang sein"
+    }
   }
 }

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -91,5 +91,58 @@
     "light": "Light",
     "dark": "Dark",
     "system": "System"
+  },
+  "auth": {
+    "appName": "Study Buddy",
+    "tagline": "Study materials of FH Joanneum",
+    "login": {
+      "title": "Sign in",
+      "subtitle": "Welcome back",
+      "emailLabel": "Email",
+      "emailPlaceholder": "first.last@edu.fh-joanneum.at",
+      "passwordLabel": "Password",
+      "passwordPlaceholder": "Your password",
+      "submit": "Sign in",
+      "submitting": "Signing in...",
+      "noAccount": "Don't have an account?",
+      "registerLink": "Register",
+      "errorTitle": "Sign in failed"
+    },
+    "register": {
+      "title": "Register",
+      "subtitle": "Create an account with your FH Joanneum email",
+      "emailLabel": "Email",
+      "emailPlaceholder": "first.last@edu.fh-joanneum.at",
+      "submit": "Register",
+      "submitting": "Sending...",
+      "haveAccount": "Already have an account?",
+      "loginLink": "Sign in",
+      "errorTitle": "Registration failed",
+      "successTitle": "Check your email",
+      "successMessage": "We sent a confirmation link to {email}. Click the link to set up your account."
+    },
+    "setup": {
+      "title": "Set up account",
+      "subtitle": "Choose a username and password",
+      "usernameLabel": "Username",
+      "usernamePlaceholder": "jane.doe",
+      "passwordLabel": "Password",
+      "passwordPlaceholder": "At least 12 characters",
+      "passwordConfirmLabel": "Confirm password",
+      "submit": "Create account",
+      "submitting": "Creating...",
+      "errorTitle": "Setup failed",
+      "missingToken": "No confirmation token found. Please use the link from your email.",
+      "passwordMismatch": "Passwords do not match"
+    },
+    "validation": {
+      "emailRequired": "Email is required",
+      "emailInvalid": "Invalid email address",
+      "emailDomain": "Only @edu.fh-joanneum.at addresses allowed",
+      "passwordRequired": "Password is required",
+      "passwordMinLength": "Password must be at least 12 characters",
+      "usernameRequired": "Username is required",
+      "usernameMinLength": "Username must be at least 3 characters"
+    }
   }
 }

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -143,6 +143,15 @@
       "passwordMinLength": "Password must be at least 12 characters",
       "usernameRequired": "Username is required",
       "usernameMinLength": "Username must be at least 3 characters"
+    },
+    "menu": {
+      "signedInAs": "Signed in as",
+      "role": "Role",
+      "logout": "Sign out",
+      "loggingOut": "Signing out..."
+    },
+    "guard": {
+      "loading": "Loading..."
     }
   }
 }

--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -4,8 +4,8 @@ import { routing } from './src/i18n/routing'
 
 const intlMiddleware = createIntlMiddleware(routing)
 
-// Auth- und Role-Checks laufen client-seitig in ProtectedRoute (AUTH-10).
-// Die echte Absicherung sitzt im Backend (require_admin, get_current_active_user).
+// Auth and role checks run client-side in ProtectedRoute (AUTH-10).
+// The real enforcement lives in the backend (require_admin, get_current_active_user).
 export default function middleware(request: NextRequest) {
   return intlMiddleware(request)
 }

--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -1,23 +1,12 @@
 import createIntlMiddleware from 'next-intl/middleware'
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { routing } from './src/i18n/routing'
 
 const intlMiddleware = createIntlMiddleware(routing)
 
-// Admin auth enforcement will be wired here once AUTH-05 is complete.
-// For now, /admin/* routes return 401 for all requests.
-function isAdminRoute(pathname: string): boolean {
-  return pathname.startsWith('/admin')
-}
-
+// Auth- und Role-Checks laufen client-seitig in ProtectedRoute (AUTH-10).
+// Die echte Absicherung sitzt im Backend (require_admin, get_current_active_user).
 export default function middleware(request: NextRequest) {
-  const { pathname } = request.nextUrl
-
-  if (isAdminRoute(pathname)) {
-    // TODO(AUTH-05): replace with real JWT role check
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  }
-
   return intlMiddleware(request)
 }
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -5,6 +5,7 @@ import type {
   SearchResponse,
   UploadMetadata,
 } from '@/types'
+import { authedFetch } from '@/lib/auth/authClient'
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8001'
 
@@ -55,9 +56,9 @@ export const api = {
     if (metadata?.category_id) formData.append('category_id', metadata.category_id)
     if (metadata?.subject_id) formData.append('subject_id', metadata.subject_id)
     if (metadata?.tags) formData.append('tags', metadata.tags)
-    return fetch(`${API_BASE_URL}/documents/upload`, { method: 'POST', body: formData }).then(handleResponse<Document>)
+    return authedFetch(`${API_BASE_URL}/documents/upload`, { method: 'POST', body: formData }).then(handleResponse<Document>)
   },
 
   deleteDocument: (id: string | number): Promise<void> =>
-    fetch(`${API_BASE_URL}/documents/${id}`, { method: 'DELETE' }).then(handleResponse<void>),
+    authedFetch(`${API_BASE_URL}/documents/${id}`, { method: 'DELETE' }).then(handleResponse<void>),
 }

--- a/frontend/src/app/(admin)/layout.tsx
+++ b/frontend/src/app/(admin)/layout.tsx
@@ -1,12 +1,16 @@
+import { ProtectedRoute } from '@/components/auth/ProtectedRoute'
+
 export default function AdminLayout({ children }: { children: React.ReactNode }) {
   return (
-    <div className="min-h-screen flex">
-      <aside className="w-64 border-r bg-muted/40 p-6 flex flex-col gap-2">
-        <span className="font-semibold text-sm text-muted-foreground uppercase tracking-wider mb-4">
-          Admin
-        </span>
-      </aside>
-      <main className="flex-1 p-8">{children}</main>
-    </div>
+    <ProtectedRoute requireRole="admin">
+      <div className="min-h-screen flex">
+        <aside className="w-64 border-r bg-muted/40 p-6 flex flex-col gap-2">
+          <span className="font-semibold text-sm text-muted-foreground uppercase tracking-wider mb-4">
+            Admin
+          </span>
+        </aside>
+        <main className="flex-1 p-8">{children}</main>
+      </div>
+    </ProtectedRoute>
   )
 }

--- a/frontend/src/app/(auth)/layout.tsx
+++ b/frontend/src/app/(auth)/layout.tsx
@@ -1,0 +1,19 @@
+import { GraduationCap } from 'lucide-react'
+import { getTranslations } from 'next-intl/server'
+
+export default async function AuthLayout({ children }: { children: React.ReactNode }) {
+  const t = await getTranslations('auth')
+
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center bg-muted/30 px-4 py-12">
+      <div className="mb-8 flex flex-col items-center gap-2 text-center">
+        <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-primary text-primary-foreground">
+          <GraduationCap className="h-6 w-6" aria-hidden />
+        </div>
+        <h1 className="text-2xl font-semibold tracking-tight">{t('appName')}</h1>
+        <p className="text-sm text-muted-foreground">{t('tagline')}</p>
+      </div>
+      <main className="w-full max-w-md">{children}</main>
+    </div>
+  )
+}

--- a/frontend/src/app/(auth)/login/page.tsx
+++ b/frontend/src/app/(auth)/login/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import Link from 'next/link'
-import { useRouter } from 'next/navigation'
+import { useRouter, useSearchParams } from 'next/navigation'
 import { useState, type FormEvent } from 'react'
 import { useTranslations } from 'next-intl'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
@@ -9,14 +9,24 @@ import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
+import { GuestRoute } from '@/components/auth/GuestRoute'
 import { useAuth } from '@/providers/AuthProvider'
 
 const EMAIL_DOMAIN = '@edu.fh-joanneum.at'
 
 export default function LoginPage() {
+  return (
+    <GuestRoute>
+      <LoginForm />
+    </GuestRoute>
+  )
+}
+
+function LoginForm() {
   const t = useTranslations('auth')
   const tv = useTranslations('auth.validation')
   const router = useRouter()
+  const searchParams = useSearchParams()
   const { login } = useAuth()
 
   const [email, setEmail] = useState('')
@@ -43,7 +53,8 @@ export default function LoginPage() {
     setError(null)
     try {
       await login({ email, password })
-      router.push('/')
+      const next = searchParams.get('next')
+      router.push(next || '/')
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err))
       setSubmitting(false)

--- a/frontend/src/app/(auth)/login/page.tsx
+++ b/frontend/src/app/(auth)/login/page.tsx
@@ -1,0 +1,106 @@
+'use client'
+
+import Link from 'next/link'
+import { useRouter } from 'next/navigation'
+import { useState, type FormEvent } from 'react'
+import { useTranslations } from 'next-intl'
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { useAuth } from '@/providers/AuthProvider'
+
+const EMAIL_DOMAIN = '@edu.fh-joanneum.at'
+
+export default function LoginPage() {
+  const t = useTranslations('auth')
+  const tv = useTranslations('auth.validation')
+  const router = useRouter()
+  const { login } = useAuth()
+
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  function validate(): string | null {
+    if (!email) return tv('emailRequired')
+    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) return tv('emailInvalid')
+    if (!email.toLowerCase().endsWith(EMAIL_DOMAIN)) return tv('emailDomain')
+    if (!password) return tv('passwordRequired')
+    return null
+  }
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>): Promise<void> {
+    event.preventDefault()
+    const validationError = validate()
+    if (validationError) {
+      setError(validationError)
+      return
+    }
+    setSubmitting(true)
+    setError(null)
+    try {
+      await login({ email, password })
+      router.push('/')
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{t('login.title')}</CardTitle>
+        <CardDescription>{t('login.subtitle')}</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          {error && (
+            <Alert variant="destructive">
+              <AlertTitle>{t('login.errorTitle')}</AlertTitle>
+              <AlertDescription>{error}</AlertDescription>
+            </Alert>
+          )}
+          <div className="space-y-2">
+            <Label htmlFor="email">{t('login.emailLabel')}</Label>
+            <Input
+              id="email"
+              type="email"
+              autoComplete="email"
+              placeholder={t('login.emailPlaceholder')}
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              disabled={submitting}
+              required
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="password">{t('login.passwordLabel')}</Label>
+            <Input
+              id="password"
+              type="password"
+              autoComplete="current-password"
+              placeholder={t('login.passwordPlaceholder')}
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              disabled={submitting}
+              required
+            />
+          </div>
+          <Button type="submit" className="w-full" disabled={submitting}>
+            {submitting ? t('login.submitting') : t('login.submit')}
+          </Button>
+          <p className="text-center text-sm text-muted-foreground">
+            {t('login.noAccount')}{' '}
+            <Link href="/register" className="text-primary underline-offset-4 hover:underline">
+              {t('login.registerLink')}
+            </Link>
+          </p>
+        </form>
+      </CardContent>
+    </Card>
+  )
+}

--- a/frontend/src/app/(auth)/register/page.tsx
+++ b/frontend/src/app/(auth)/register/page.tsx
@@ -8,11 +8,20 @@ import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
+import { GuestRoute } from '@/components/auth/GuestRoute'
 import { useAuth } from '@/providers/AuthProvider'
 
 const EMAIL_DOMAIN = '@edu.fh-joanneum.at'
 
 export default function RegisterPage() {
+  return (
+    <GuestRoute>
+      <RegisterForm />
+    </GuestRoute>
+  )
+}
+
+function RegisterForm() {
   const t = useTranslations('auth')
   const tv = useTranslations('auth.validation')
   const { register } = useAuth()

--- a/frontend/src/app/(auth)/register/page.tsx
+++ b/frontend/src/app/(auth)/register/page.tsx
@@ -1,0 +1,109 @@
+'use client'
+
+import Link from 'next/link'
+import { useState, type FormEvent } from 'react'
+import { useTranslations } from 'next-intl'
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { useAuth } from '@/providers/AuthProvider'
+
+const EMAIL_DOMAIN = '@edu.fh-joanneum.at'
+
+export default function RegisterPage() {
+  const t = useTranslations('auth')
+  const tv = useTranslations('auth.validation')
+  const { register } = useAuth()
+
+  const [email, setEmail] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [submittedEmail, setSubmittedEmail] = useState<string | null>(null)
+
+  function validate(): string | null {
+    if (!email) return tv('emailRequired')
+    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) return tv('emailInvalid')
+    if (!email.toLowerCase().endsWith(EMAIL_DOMAIN)) return tv('emailDomain')
+    return null
+  }
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>): Promise<void> {
+    event.preventDefault()
+    const validationError = validate()
+    if (validationError) {
+      setError(validationError)
+      return
+    }
+    setSubmitting(true)
+    setError(null)
+    try {
+      await register({ email })
+      setSubmittedEmail(email)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  if (submittedEmail) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>{t('register.successTitle')}</CardTitle>
+          <CardDescription>
+            {t('register.successMessage', { email: submittedEmail })}
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Link href="/login" className="text-sm text-primary underline-offset-4 hover:underline">
+            {t('login.title')}
+          </Link>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{t('register.title')}</CardTitle>
+        <CardDescription>{t('register.subtitle')}</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          {error && (
+            <Alert variant="destructive">
+              <AlertTitle>{t('register.errorTitle')}</AlertTitle>
+              <AlertDescription>{error}</AlertDescription>
+            </Alert>
+          )}
+          <div className="space-y-2">
+            <Label htmlFor="email">{t('register.emailLabel')}</Label>
+            <Input
+              id="email"
+              type="email"
+              autoComplete="email"
+              placeholder={t('register.emailPlaceholder')}
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              disabled={submitting}
+              required
+            />
+          </div>
+          <Button type="submit" className="w-full" disabled={submitting}>
+            {submitting ? t('register.submitting') : t('register.submit')}
+          </Button>
+          <p className="text-center text-sm text-muted-foreground">
+            {t('register.haveAccount')}{' '}
+            <Link href="/login" className="text-primary underline-offset-4 hover:underline">
+              {t('register.loginLink')}
+            </Link>
+          </p>
+        </form>
+      </CardContent>
+    </Card>
+  )
+}

--- a/frontend/src/app/(auth)/setup/page.tsx
+++ b/frontend/src/app/(auth)/setup/page.tsx
@@ -1,0 +1,118 @@
+'use client'
+
+import { useRouter, useSearchParams } from 'next/navigation'
+import { useState, type FormEvent } from 'react'
+import { useTranslations } from 'next-intl'
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { useAuth } from '@/providers/AuthProvider'
+
+const PASSWORD_MIN_LENGTH = 12
+const USERNAME_MIN_LENGTH = 3
+
+export default function SetupPage() {
+  const t = useTranslations('auth')
+  const tv = useTranslations('auth.validation')
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const { setup } = useAuth()
+
+  const verifyToken = searchParams.get('token') ?? ''
+
+  const [username, setUsername] = useState('')
+  const [password, setPassword] = useState('')
+  const [passwordConfirm, setPasswordConfirm] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  function validate(): string | null {
+    if (!verifyToken) return t('setup.missingToken')
+    if (!username) return tv('usernameRequired')
+    if (username.length < USERNAME_MIN_LENGTH) return tv('usernameMinLength')
+    if (!password) return tv('passwordRequired')
+    if (password.length < PASSWORD_MIN_LENGTH) return tv('passwordMinLength')
+    if (password !== passwordConfirm) return t('setup.passwordMismatch')
+    return null
+  }
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>): Promise<void> {
+    event.preventDefault()
+    const validationError = validate()
+    if (validationError) {
+      setError(validationError)
+      return
+    }
+    setSubmitting(true)
+    setError(null)
+    try {
+      await setup({ token: verifyToken, username, password })
+      router.push('/')
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{t('setup.title')}</CardTitle>
+        <CardDescription>{t('setup.subtitle')}</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          {error && (
+            <Alert variant="destructive">
+              <AlertTitle>{t('setup.errorTitle')}</AlertTitle>
+              <AlertDescription>{error}</AlertDescription>
+            </Alert>
+          )}
+          <div className="space-y-2">
+            <Label htmlFor="username">{t('setup.usernameLabel')}</Label>
+            <Input
+              id="username"
+              type="text"
+              autoComplete="username"
+              placeholder={t('setup.usernamePlaceholder')}
+              value={username}
+              onChange={(e) => setUsername(e.target.value)}
+              disabled={submitting}
+              required
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="password">{t('setup.passwordLabel')}</Label>
+            <Input
+              id="password"
+              type="password"
+              autoComplete="new-password"
+              placeholder={t('setup.passwordPlaceholder')}
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              disabled={submitting}
+              required
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="passwordConfirm">{t('setup.passwordConfirmLabel')}</Label>
+            <Input
+              id="passwordConfirm"
+              type="password"
+              autoComplete="new-password"
+              value={passwordConfirm}
+              onChange={(e) => setPasswordConfirm(e.target.value)}
+              disabled={submitting}
+              required
+            />
+          </div>
+          <Button type="submit" className="w-full" disabled={submitting}>
+            {submitting ? t('setup.submitting') : t('setup.submit')}
+          </Button>
+        </form>
+      </CardContent>
+    </Card>
+  )
+}

--- a/frontend/src/app/(student)/layout.tsx
+++ b/frontend/src/app/(student)/layout.tsx
@@ -1,3 +1,5 @@
+import { ProtectedRoute } from '@/components/auth/ProtectedRoute'
+
 export default function StudentLayout({ children }: { children: React.ReactNode }) {
-  return <>{children}</>
+  return <ProtectedRoute>{children}</ProtectedRoute>
 }

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import { Plus_Jakarta_Sans, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { ThemeProvider } from "@/providers/ThemeProvider";
+import { AuthProvider } from "@/providers/AuthProvider";
 import { FiltersProvider } from "@/providers/FiltersProvider";
 import { NextIntlClientProvider } from "next-intl";
 import { getLocale, getMessages } from "next-intl/server";
@@ -31,9 +32,11 @@ export default async function RootLayout({ children }: { children: React.ReactNo
       <body className={`${plusJakartaSans.variable} ${geistMono.variable} antialiased bg-background text-foreground`}>
         <ThemeProvider>
           <NextIntlClientProvider messages={messages}>
-            <FiltersProvider>
-              {children}
-            </FiltersProvider>
+            <AuthProvider>
+              <FiltersProvider>
+                {children}
+              </FiltersProvider>
+            </AuthProvider>
           </NextIntlClientProvider>
         </ThemeProvider>
       </body>

--- a/frontend/src/components/auth/GuestRoute.tsx
+++ b/frontend/src/components/auth/GuestRoute.tsx
@@ -1,0 +1,44 @@
+'use client'
+
+import { useEffect } from 'react'
+import { useRouter, useSearchParams } from 'next/navigation'
+import { useTranslations } from 'next-intl'
+import { useAuth } from '@/providers/AuthProvider'
+
+/**
+ * Inverse von ProtectedRoute: eingeloggte User werden weggeleitet (Default: /).
+ * Setup-Page bekommt eine Sonderbehandlung — siehe allowWhenAuthenticated.
+ */
+export function GuestRoute({
+  children,
+  redirectTo = '/',
+  allowWhenAuthenticated = false,
+}: {
+  children: React.ReactNode
+  redirectTo?: string
+  allowWhenAuthenticated?: boolean
+}): React.ReactNode {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const { status } = useAuth()
+  const t = useTranslations('auth.guard')
+
+  useEffect(() => {
+    if (allowWhenAuthenticated) return
+    if (status === 'authenticated') {
+      const next = searchParams.get('next')
+      router.replace(next || redirectTo)
+    }
+  }, [status, router, searchParams, redirectTo, allowWhenAuthenticated])
+
+  if (status === 'loading') {
+    return (
+      <div className="flex items-center justify-center py-10">
+        <span className="text-sm text-muted-foreground">{t('loading')}</span>
+      </div>
+    )
+  }
+
+  if (status === 'authenticated' && !allowWhenAuthenticated) return null
+  return <>{children}</>
+}

--- a/frontend/src/components/auth/GuestRoute.tsx
+++ b/frontend/src/components/auth/GuestRoute.tsx
@@ -6,8 +6,8 @@ import { useTranslations } from 'next-intl'
 import { useAuth } from '@/providers/AuthProvider'
 
 /**
- * Inverse von ProtectedRoute: eingeloggte User werden weggeleitet (Default: /).
- * Setup-Page bekommt eine Sonderbehandlung — siehe allowWhenAuthenticated.
+ * Inverse of ProtectedRoute: authenticated users get redirected away (default: /).
+ * The setup page is the exception — see allowWhenAuthenticated.
  */
 export function GuestRoute({
   children,

--- a/frontend/src/components/auth/ProtectedRoute.tsx
+++ b/frontend/src/components/auth/ProtectedRoute.tsx
@@ -9,16 +9,16 @@ import type { UserRole } from '@/types/auth'
 interface ProtectedRouteProps {
   children: React.ReactNode
   /**
-   * Optional: nur User mit dieser Rolle dürfen rein. Ohne Wert reicht ein
-   * eingeloggter, aktiver User.
+   * Optional: only users with this role are let through. When omitted, any
+   * authenticated and active user is accepted.
    */
   requireRole?: UserRole
   /**
-   * Wohin redirected wird, wenn unauthentifiziert. Default: /login
+   * Redirect target when unauthenticated. Default: /login
    */
   loginRedirect?: string
   /**
-   * Wohin redirected wird, wenn eingeloggt aber falsche Rolle. Default: /
+   * Redirect target when authenticated but with the wrong role. Default: /
    */
   forbiddenRedirect?: string
 }

--- a/frontend/src/components/auth/ProtectedRoute.tsx
+++ b/frontend/src/components/auth/ProtectedRoute.tsx
@@ -1,0 +1,60 @@
+'use client'
+
+import { useEffect } from 'react'
+import { usePathname, useRouter } from 'next/navigation'
+import { useTranslations } from 'next-intl'
+import { useAuth } from '@/providers/AuthProvider'
+import type { UserRole } from '@/types/auth'
+
+interface ProtectedRouteProps {
+  children: React.ReactNode
+  /**
+   * Optional: nur User mit dieser Rolle dürfen rein. Ohne Wert reicht ein
+   * eingeloggter, aktiver User.
+   */
+  requireRole?: UserRole
+  /**
+   * Wohin redirected wird, wenn unauthentifiziert. Default: /login
+   */
+  loginRedirect?: string
+  /**
+   * Wohin redirected wird, wenn eingeloggt aber falsche Rolle. Default: /
+   */
+  forbiddenRedirect?: string
+}
+
+export function ProtectedRoute({
+  children,
+  requireRole,
+  loginRedirect = '/login',
+  forbiddenRedirect = '/',
+}: ProtectedRouteProps): React.ReactNode {
+  const router = useRouter()
+  const pathname = usePathname()
+  const { status, user } = useAuth()
+  const t = useTranslations('auth.guard')
+
+  useEffect(() => {
+    if (status === 'unauthenticated') {
+      const next = encodeURIComponent(pathname || '/')
+      router.replace(`${loginRedirect}?next=${next}`)
+      return
+    }
+    if (status === 'authenticated' && requireRole && user?.role !== requireRole) {
+      router.replace(forbiddenRedirect)
+    }
+  }, [status, user, requireRole, router, pathname, loginRedirect, forbiddenRedirect])
+
+  if (status === 'loading') {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <span className="text-sm text-muted-foreground">{t('loading')}</span>
+      </div>
+    )
+  }
+
+  if (status === 'unauthenticated') return null
+  if (requireRole && user?.role !== requireRole) return null
+
+  return <>{children}</>
+}

--- a/frontend/src/components/layout/UserPreferencesMenu.tsx
+++ b/frontend/src/components/layout/UserPreferencesMenu.tsx
@@ -1,10 +1,10 @@
 'use client'
 
-import { Sun, Moon, Monitor, Languages, PaletteIcon } from 'lucide-react'
+import { LogOut, Sun, Moon, Monitor, Languages, PaletteIcon } from 'lucide-react'
 import { useTheme } from 'next-themes'
 import { useTranslations, useLocale } from 'next-intl'
 import { useRouter } from 'next/navigation'
-import { useTransition } from 'react'
+import { useState, useTransition } from 'react'
 import { setLocale } from '@/app/actions'
 import type { Locale } from '@/i18n/routing'
 import { Button } from '@/components/ui/button'
@@ -13,14 +13,18 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuLabel,
   DropdownMenuPortal,
   DropdownMenuRadioGroup,
   DropdownMenuRadioItem,
+  DropdownMenuSeparator,
   DropdownMenuSub,
   DropdownMenuSubContent,
   DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
+import { useAuth } from '@/providers/AuthProvider'
 
 export function UserPreferencesMenu() {
   const t = useTranslations()
@@ -28,6 +32,8 @@ export function UserPreferencesMenu() {
   const { theme, setTheme } = useTheme()
   const router = useRouter()
   const [, startTransition] = useTransition()
+  const { user, status, logout } = useAuth()
+  const [loggingOut, setLoggingOut] = useState(false)
 
   const handleLocaleChange = (newLocale: string) => {
     startTransition(async () => {
@@ -36,17 +42,52 @@ export function UserPreferencesMenu() {
     })
   }
 
+  const handleLogout = async () => {
+    setLoggingOut(true)
+    try {
+      await logout()
+      router.push('/login')
+    } finally {
+      setLoggingOut(false)
+    }
+  }
+
+  const initials = user?.username
+    ? user.username.slice(0, 2).toUpperCase()
+    : user?.email
+      ? user.email.slice(0, 2).toUpperCase()
+      : 'SB'
+
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
         <Button variant="ghost" size="icon" className="rounded-full">
           <Avatar className="w-8 h-8">
-            <AvatarImage src="https://github.com/shadcn.png" alt="User" />
-            <AvatarFallback>SB</AvatarFallback>
+            <AvatarImage src="" alt="User" />
+            <AvatarFallback>{initials}</AvatarFallback>
           </Avatar>
         </Button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="end" className="w-44">
+      <DropdownMenuContent align="end" className="w-56">
+        {status === 'authenticated' && user && (
+          <>
+            <DropdownMenuLabel className="font-normal">
+              <div className="flex flex-col gap-1">
+                <span className="text-xs text-muted-foreground">
+                  {t('auth.menu.signedInAs')}
+                </span>
+                <span className="text-sm font-medium truncate">
+                  {user.username ?? user.email}
+                </span>
+                <span className="text-xs text-muted-foreground capitalize">
+                  {t('auth.menu.role')}: {user.role}
+                </span>
+              </div>
+            </DropdownMenuLabel>
+            <DropdownMenuSeparator />
+          </>
+        )}
+
         <DropdownMenuGroup>
           <DropdownMenuSub>
             <DropdownMenuSubTrigger>
@@ -92,6 +133,23 @@ export function UserPreferencesMenu() {
             </DropdownMenuPortal>
           </DropdownMenuSub>
         </DropdownMenuGroup>
+
+        {status === 'authenticated' && (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem
+              onSelect={(e) => {
+                e.preventDefault()
+                void handleLogout()
+              }}
+              disabled={loggingOut}
+              variant="destructive"
+            >
+              <LogOut className="w-4 h-4" />
+              {loggingOut ? t('auth.menu.loggingOut') : t('auth.menu.logout')}
+            </DropdownMenuItem>
+          </>
+        )}
       </DropdownMenuContent>
     </DropdownMenu>
   )

--- a/frontend/src/lib/auth/authClient.ts
+++ b/frontend/src/lib/auth/authClient.ts
@@ -1,0 +1,187 @@
+import type {
+  LoginRequest,
+  RegisterRequest,
+  SetupRequest,
+  TokenResponse,
+  User,
+} from '@/types/auth'
+import {
+  clearAccessToken,
+  getAccessToken,
+  getSecondsUntilExpiry,
+  setAccessToken,
+} from './tokenStore'
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8001'
+
+/**
+ * Refresh proaktiv, wenn der Access Token in weniger als REFRESH_LEEWAY_SECONDS abläuft.
+ * 60s ist sicherer Default — verhindert Race mit Server-Clock-Drift.
+ */
+const REFRESH_LEEWAY_SECONDS = 60
+
+class AuthError extends Error {
+  status: number
+  constructor(message: string, status: number) {
+    super(message)
+    this.status = status
+    this.name = 'AuthError'
+  }
+}
+
+async function parseError(response: Response): Promise<string> {
+  try {
+    const body = (await response.json()) as { detail?: string; message?: string }
+    return body.detail || body.message || response.statusText
+  } catch {
+    return response.statusText
+  }
+}
+
+/**
+ * Mutex für parallele Refresh-Versuche. Bei n gleichzeitigen Requests, die alle
+ * refreshen wollen, läuft genau ein Network-Call und alle warten auf dasselbe Promise.
+ * Nach Auflösung wird das Promise wieder genullt, damit der nächste Refresh frisch startet.
+ */
+let refreshInFlight: Promise<boolean> | null = null
+
+async function performRefresh(): Promise<boolean> {
+  const response = await fetch(`${API_BASE_URL}/auth/refresh`, {
+    method: 'POST',
+    credentials: 'include',
+  })
+
+  if (!response.ok) {
+    clearAccessToken()
+    return false
+  }
+
+  const data = (await response.json()) as TokenResponse
+  setAccessToken(data.access_token)
+  return true
+}
+
+function refresh(): Promise<boolean> {
+  if (refreshInFlight) return refreshInFlight
+  refreshInFlight = performRefresh().finally(() => {
+    refreshInFlight = null
+  })
+  return refreshInFlight
+}
+
+async function ensureFreshToken(): Promise<string | null> {
+  const token = getAccessToken()
+  if (!token) return null
+  const seconds = getSecondsUntilExpiry()
+  if (seconds === null || seconds < REFRESH_LEEWAY_SECONDS) {
+    const ok = await refresh()
+    return ok ? getAccessToken() : null
+  }
+  return token
+}
+
+/**
+ * Wrapper für authentifizierte Requests: Proactive Refresh + Lazy Fallback bei 401.
+ * Refresh wird genau einmal pro Request versucht — bei wiederholtem 401 kommt der
+ * Error durch, damit der Caller (z.B. UI) auf die Login-Seite umleiten kann.
+ */
+export async function authedFetch(input: string, init: RequestInit = {}): Promise<Response> {
+  const headers = new Headers(init.headers)
+
+  const fresh = await ensureFreshToken()
+  if (fresh) headers.set('Authorization', `Bearer ${fresh}`)
+
+  let response = await fetch(input, { ...init, headers })
+
+  if (response.status === 401 && fresh) {
+    const ok = await refresh()
+    if (!ok) return response
+    const retryHeaders = new Headers(init.headers)
+    const retryToken = getAccessToken()
+    if (retryToken) retryHeaders.set('Authorization', `Bearer ${retryToken}`)
+    response = await fetch(input, { ...init, headers: retryHeaders })
+  }
+
+  return response
+}
+
+async function handleJson<T>(response: Response): Promise<T> {
+  if (!response.ok) {
+    throw new AuthError(await parseError(response), response.status)
+  }
+  return response.json() as Promise<T>
+}
+
+async function expectStatus(response: Response, expected: number): Promise<void> {
+  if (response.status !== expected) {
+    throw new AuthError(await parseError(response), response.status)
+  }
+}
+
+export const authClient = {
+  /**
+   * Schritt 1 des Onboardings: Email registrieren, Verify-Mail wird verschickt (AUTH-16).
+   */
+  async register(body: RegisterRequest): Promise<User> {
+    const response = await fetch(`${API_BASE_URL}/auth/register`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    })
+    return handleJson<User>(response)
+  },
+
+  /**
+   * Schritt 2: Verify-Token + Username + Passwort einlösen, Access Token landet im Store.
+   */
+  async setup(body: SetupRequest): Promise<TokenResponse> {
+    const response = await fetch(`${API_BASE_URL}/auth/setup`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify(body),
+    })
+    const data = await handleJson<TokenResponse>(response)
+    setAccessToken(data.access_token)
+    return data
+  },
+
+  async login(body: LoginRequest): Promise<TokenResponse> {
+    // Backend nutzt OAuth2PasswordRequestForm — username/password als x-www-form-urlencoded
+    const formData = new URLSearchParams()
+    formData.set('username', body.email)
+    formData.set('password', body.password)
+
+    const response = await fetch(`${API_BASE_URL}/auth/login`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      credentials: 'include',
+      body: formData,
+    })
+    const data = await handleJson<TokenResponse>(response)
+    setAccessToken(data.access_token)
+    return data
+  },
+
+  async logout(): Promise<void> {
+    const response = await authedFetch(`${API_BASE_URL}/auth/logout`, {
+      method: 'POST',
+      credentials: 'include',
+    })
+    clearAccessToken()
+    if (response.status !== 204 && !response.ok) {
+      throw new AuthError(await parseError(response), response.status)
+    }
+  },
+
+  async refresh(): Promise<boolean> {
+    return refresh()
+  },
+
+  async getMe(): Promise<User> {
+    const response = await authedFetch(`${API_BASE_URL}/auth/me`)
+    return handleJson<User>(response)
+  },
+}
+
+export { AuthError }

--- a/frontend/src/lib/auth/authClient.ts
+++ b/frontend/src/lib/auth/authClient.ts
@@ -15,8 +15,8 @@ import {
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8001'
 
 /**
- * Refresh proaktiv, wenn der Access Token in weniger als REFRESH_LEEWAY_SECONDS abläuft.
- * 60s ist sicherer Default — verhindert Race mit Server-Clock-Drift.
+ * Refresh proactively if the access token expires in less than REFRESH_LEEWAY_SECONDS.
+ * 60s is a safe default — accounts for minor server/client clock drift.
  */
 const REFRESH_LEEWAY_SECONDS = 60
 
@@ -39,9 +39,9 @@ async function parseError(response: Response): Promise<string> {
 }
 
 /**
- * Mutex für parallele Refresh-Versuche. Bei n gleichzeitigen Requests, die alle
- * refreshen wollen, läuft genau ein Network-Call und alle warten auf dasselbe Promise.
- * Nach Auflösung wird das Promise wieder genullt, damit der nächste Refresh frisch startet.
+ * Mutex for parallel refresh attempts. With n concurrent requests all wanting
+ * to refresh, only one network call runs; the rest await the same promise.
+ * After it resolves, the slot is cleared so the next refresh starts fresh.
  */
 let refreshInFlight: Promise<boolean> | null = null
 
@@ -81,9 +81,9 @@ async function ensureFreshToken(): Promise<string | null> {
 }
 
 /**
- * Wrapper für authentifizierte Requests: Proactive Refresh + Lazy Fallback bei 401.
- * Refresh wird genau einmal pro Request versucht — bei wiederholtem 401 kommt der
- * Error durch, damit der Caller (z.B. UI) auf die Login-Seite umleiten kann.
+ * Wrapper for authenticated requests: proactive refresh + lazy fallback on 401.
+ * Refresh is attempted at most once per request — a repeated 401 surfaces the
+ * error so callers (e.g. UI) can redirect to the login page.
  */
 export async function authedFetch(input: string, init: RequestInit = {}): Promise<Response> {
   const headers = new Headers(init.headers)
@@ -112,15 +112,9 @@ async function handleJson<T>(response: Response): Promise<T> {
   return response.json() as Promise<T>
 }
 
-async function expectStatus(response: Response, expected: number): Promise<void> {
-  if (response.status !== expected) {
-    throw new AuthError(await parseError(response), response.status)
-  }
-}
-
 export const authClient = {
   /**
-   * Schritt 1 des Onboardings: Email registrieren, Verify-Mail wird verschickt (AUTH-16).
+   * Step 1 of onboarding: register the email; verify mail is sent (AUTH-16).
    */
   async register(body: RegisterRequest): Promise<User> {
     const response = await fetch(`${API_BASE_URL}/auth/register`, {
@@ -132,7 +126,8 @@ export const authClient = {
   },
 
   /**
-   * Schritt 2: Verify-Token + Username + Passwort einlösen, Access Token landet im Store.
+   * Step 2: redeem the verify token together with username + password; the
+   * access token lands in the in-memory store.
    */
   async setup(body: SetupRequest): Promise<TokenResponse> {
     const response = await fetch(`${API_BASE_URL}/auth/setup`, {
@@ -147,7 +142,7 @@ export const authClient = {
   },
 
   async login(body: LoginRequest): Promise<TokenResponse> {
-    // Backend nutzt OAuth2PasswordRequestForm — username/password als x-www-form-urlencoded
+    // Backend uses OAuth2PasswordRequestForm — username/password as x-www-form-urlencoded
     const formData = new URLSearchParams()
     formData.set('username', body.email)
     formData.set('password', body.password)

--- a/frontend/src/lib/auth/tokenStore.ts
+++ b/frontend/src/lib/auth/tokenStore.ts
@@ -1,0 +1,51 @@
+import type { JwtPayload } from '@/types/auth'
+
+let accessToken: string | null = null
+let cachedPayload: JwtPayload | null = null
+
+type Listener = (token: string | null) => void
+const listeners = new Set<Listener>()
+
+export function setAccessToken(token: string | null): void {
+  accessToken = token
+  cachedPayload = token ? decodePayload(token) : null
+  listeners.forEach((listener) => listener(token))
+}
+
+export function getAccessToken(): string | null {
+  return accessToken
+}
+
+export function clearAccessToken(): void {
+  setAccessToken(null)
+}
+
+export function getTokenPayload(): JwtPayload | null {
+  return cachedPayload
+}
+
+/**
+ * Returns seconds until token expires. Negative if already expired, null if no token.
+ */
+export function getSecondsUntilExpiry(): number | null {
+  if (!cachedPayload) return null
+  const nowSeconds = Math.floor(Date.now() / 1000)
+  return cachedPayload.exp - nowSeconds
+}
+
+export function subscribe(listener: Listener): () => void {
+  listeners.add(listener)
+  return () => listeners.delete(listener)
+}
+
+function decodePayload(token: string): JwtPayload | null {
+  try {
+    const [, payloadB64] = token.split('.')
+    if (!payloadB64) return null
+    const padded = payloadB64 + '='.repeat((4 - (payloadB64.length % 4)) % 4)
+    const json = atob(padded.replace(/-/g, '+').replace(/_/g, '/'))
+    return JSON.parse(json) as JwtPayload
+  } catch {
+    return null
+  }
+}

--- a/frontend/src/providers/AuthProvider.tsx
+++ b/frontend/src/providers/AuthProvider.tsx
@@ -35,8 +35,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     }
   }, [])
 
-  // App-Bootstrap: einmaliger Silent Refresh über Cookie. Klappt es, ziehen wir
-  // direkt /me; sonst Status auf unauthenticated.
+  // App bootstrap: single silent refresh via cookie. On success we load /me;
+  // otherwise the status drops to unauthenticated.
   useEffect(() => {
     if (bootstrapped.current) return
     bootstrapped.current = true
@@ -58,7 +58,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     }
   }, [loadUser])
 
-  // Token-Wechsel aus authClient (z.B. nach login/setup) → User refreshen.
+  // Token changes from authClient (e.g. after login/setup) trigger a /me reload.
   useEffect(() => {
     return subscribe((token) => {
       if (token) {
@@ -72,7 +72,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
   const login = useCallback(async (body: LoginRequest): Promise<void> => {
     await authClient.login(body)
-    // loadUser läuft über subscribe-Listener nach setAccessToken
+    // loadUser runs via the subscribe listener after setAccessToken
   }, [])
 
   const register = useCallback(async (body: RegisterRequest): Promise<User> => {
@@ -87,7 +87,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     try {
       await authClient.logout()
     } catch (err) {
-      // Logout-Fehler nicht durchreichen: lokal sind wir trotzdem ausgeloggt
+      // Don't propagate logout errors — the client is logged out locally regardless
       if (!(err instanceof AuthError) || err.status !== 401) {
         console.error('Logout request failed:', err)
       }

--- a/frontend/src/providers/AuthProvider.tsx
+++ b/frontend/src/providers/AuthProvider.tsx
@@ -1,0 +1,113 @@
+'use client'
+
+import { createContext, useCallback, useContext, useEffect, useRef, useState } from 'react'
+import { authClient, AuthError } from '@/lib/auth/authClient'
+import { getAccessToken, subscribe } from '@/lib/auth/tokenStore'
+import type { LoginRequest, RegisterRequest, SetupRequest, User } from '@/types/auth'
+
+type AuthStatus = 'loading' | 'authenticated' | 'unauthenticated'
+
+interface AuthContextValue {
+  user: User | null
+  status: AuthStatus
+  login: (body: LoginRequest) => Promise<void>
+  register: (body: RegisterRequest) => Promise<User>
+  setup: (body: SetupRequest) => Promise<void>
+  logout: () => Promise<void>
+  refreshUser: () => Promise<void>
+}
+
+const AuthContext = createContext<AuthContextValue | null>(null)
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [user, setUser] = useState<User | null>(null)
+  const [status, setStatus] = useState<AuthStatus>('loading')
+  const bootstrapped = useRef(false)
+
+  const loadUser = useCallback(async (): Promise<void> => {
+    try {
+      const me = await authClient.getMe()
+      setUser(me)
+      setStatus('authenticated')
+    } catch {
+      setUser(null)
+      setStatus('unauthenticated')
+    }
+  }, [])
+
+  // App-Bootstrap: einmaliger Silent Refresh über Cookie. Klappt es, ziehen wir
+  // direkt /me; sonst Status auf unauthenticated.
+  useEffect(() => {
+    if (bootstrapped.current) return
+    bootstrapped.current = true
+
+    let cancelled = false
+    void (async () => {
+      const refreshed = await authClient.refresh()
+      if (cancelled) return
+      if (refreshed) {
+        await loadUser()
+      } else {
+        setUser(null)
+        setStatus('unauthenticated')
+      }
+    })()
+
+    return () => {
+      cancelled = true
+    }
+  }, [loadUser])
+
+  // Token-Wechsel aus authClient (z.B. nach login/setup) → User refreshen.
+  useEffect(() => {
+    return subscribe((token) => {
+      if (token) {
+        void loadUser()
+      } else {
+        setUser(null)
+        setStatus('unauthenticated')
+      }
+    })
+  }, [loadUser])
+
+  const login = useCallback(async (body: LoginRequest): Promise<void> => {
+    await authClient.login(body)
+    // loadUser läuft über subscribe-Listener nach setAccessToken
+  }, [])
+
+  const register = useCallback(async (body: RegisterRequest): Promise<User> => {
+    return authClient.register(body)
+  }, [])
+
+  const setup = useCallback(async (body: SetupRequest): Promise<void> => {
+    await authClient.setup(body)
+  }, [])
+
+  const logout = useCallback(async (): Promise<void> => {
+    try {
+      await authClient.logout()
+    } catch (err) {
+      // Logout-Fehler nicht durchreichen: lokal sind wir trotzdem ausgeloggt
+      if (!(err instanceof AuthError) || err.status !== 401) {
+        console.error('Logout request failed:', err)
+      }
+    }
+  }, [])
+
+  const refreshUser = useCallback(async (): Promise<void> => {
+    if (!getAccessToken()) return
+    await loadUser()
+  }, [loadUser])
+
+  return (
+    <AuthContext.Provider value={{ user, status, login, register, setup, logout, refreshUser }}>
+      {children}
+    </AuthContext.Provider>
+  )
+}
+
+export function useAuth(): AuthContextValue {
+  const ctx = useContext(AuthContext)
+  if (!ctx) throw new Error('useAuth must be used within an AuthProvider')
+  return ctx
+}

--- a/frontend/src/types/auth.ts
+++ b/frontend/src/types/auth.ts
@@ -1,0 +1,41 @@
+export type UserRole = 'student' | 'admin'
+
+export interface User {
+  id: number
+  email: string
+  username: string | null
+  role: UserRole
+  is_active: boolean
+  email_verified_at: string | null
+  created_at: string
+}
+
+export interface TokenResponse {
+  access_token: string
+  token_type: string
+}
+
+export interface RegisterRequest {
+  email: string
+}
+
+export interface SetupRequest {
+  token: string
+  username: string
+  password: string
+}
+
+export interface LoginRequest {
+  email: string
+  password: string
+}
+
+export interface JwtPayload {
+  sub: string
+  exp: number
+  iat: number
+  jti: string
+  type: string
+  iss: string
+  aud: string
+}


### PR DESCRIPTION
## Summary

Implements the complete JWT-based auth system across backend and frontend:
registration with email verification, login/setup/logout, refresh-token
rotation in an HttpOnly cookie, role-based authorization, rate-limited
auth endpoints, and UI guards.

Closes AUTH-05, AUTH-06, AUTH-07, AUTH-08, AUTH-09, AUTH-10, AUTH-11,
AUTH-12, AUTH-13, AUTH-14, AUTH-15, AUTH-16, AUTH-17.

## Backend

- **Endpoints** (`/api/auth/*`): `register`, `setup`, `login`, `refresh`,
  `logout`, `me`. Refresh + logout read the refresh token from an
  HttpOnly cookie; access tokens stay in the JSON body.
- **Storage** (ADR-0001): refresh token in `Secure; SameSite=Strict;
  HttpOnly; Path=/api/auth` cookie; access token client-side in memory only.
- **Token revocation:** JTI denylist in Redis on logout — access tokens
  become invalid the moment the user signs out.
- **Refresh-token rotation** on every refresh, with O(log n) indexed
  lookup by `token_hash` (no more table scan).
- **Authorization:** `get_current_active_user` enforces login + verified
  email; `require_admin` factory for role gates. Filter mutations are
  admin-only. Document delete is uploader-or-admin.
- **Rate limiting** via SlowAPI + Redis: 3/min register, 5/min setup,
  5/min login, 10/min refresh.
- **Email verification**: Mailpit for local dev (UI on port 8025);
  real SMTP via `.env` in production.
- **Password hashing:** Argon2 via passlib.
- **Hardening:** unified 401 across auth failures (no user enumeration),
  HS256-only via `Literal` type, `iss`/`aud` claims.

## Frontend (Next.js 16)

- **In-memory token store** with JWT-payload decoder and pub/sub subscribers.
- **`authClient`** with proactive refresh (60s leeway), refresh-mutex
  to serialize parallel attempts, and lazy fallback on 401.
- **`AuthProvider` + `useAuth` hook**: silent refresh on app load via
  the cookie, automatic `/me` reload on token changes.
- **Pages**: `/login`, `/register`, `/setup?token=...` with centered-
  card layout, client-side validation, and DE/EN i18n.
- **Route guards**: `ProtectedRoute` (with optional role) on `(student)`
  and `(admin)` layouts; `GuestRoute` redirects logged-in users away
  from login/register and respects `?next=`.
- **User menu**: replaces the static avatar with user-initials, shows
  email/role, exposes a Logout action.
- **Middleware**: removed the placeholder blanket-401 on `/admin/*` —
  real enforcement is now the backend's `require_admin`.

## Docs

- `docs/adr/0001-jwt-storage-strategy.md` — full rationale for the
  hybrid storage decision.
- `docs/local-testing-guide.md` — env setup, `make` targets, service
  URLs, end-to-end auth walkthrough including Mailpit.
- `backend/docs/auth-implementation.md` — complete reference of the
  auth system with design-decision rationale.
- `backend/.env-example` — expanded with JWT, cookie, and mail settings.

## Infrastructure

- Mailpit added to `docker/local/docker-compose.yml` (SMTP 1025,
  Web UI 8025, no auth, no TLS).
- New `app/core/limiter.py` to break a circular import between routes
  and `main`.