### PR TITLE
docs+infra: local testing guide, adr refresh, server stack updates

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -28,11 +28,11 @@ clean:
 	find . -type d -name "*.egg-info" -exec rm -rf {} +
 
 db-up:
-	docker compose up -d
+	docker compose -f ../docker/local/docker-compose.yml --env-file ../docker/local/.env up -d
 
 db-down:
-	docker compose down
+	docker compose -f ../docker/local/docker-compose.yml --env-file ../docker/local/.env down
 
 db-reset:
-	docker compose down -v
-	docker compose up -d
+	docker compose -f ../docker/local/docker-compose.yml --env-file ../docker/local/.env down -v
+	docker compose -f ../docker/local/docker-compose.yml --env-file ../docker/local/.env up -d

--- a/docker/server/prod/docker-compose.yml
+++ b/docker/server/prod/docker-compose.yml
@@ -44,10 +44,23 @@ services:
     networks:
       - studybuddy-network
 
+  redis:
+    image: redis:7-alpine
+    container_name: studybuddy-redis
+    restart: unless-stopped
+    volumes:
+      - redis_data:/data
+    ports:
+      - "6379:6379"
+    networks:
+      - studybuddy-network
+
 volumes:
   postgres_data:
     driver: local
   weaviate_data:
+    driver: local
+  redis_data:
     driver: local
 
 networks:

--- a/docker/server/staging/docker-compose.yml
+++ b/docker/server/staging/docker-compose.yml
@@ -44,10 +44,37 @@ services:
     networks:
       - studybuddy-staging-network
 
+  redis:
+    image: redis:7-alpine
+    container_name: studybuddy-staging-redis
+    restart: unless-stopped
+    volumes:
+      - redis_staging_data:/data
+    ports:
+      - "6379:6379"
+    networks:
+      - studybuddy-staging-network
+
+  mailpit:
+    image: axllent/mailpit:latest
+    container_name: studybuddy-staging-mailpit
+    restart: unless-stopped
+    ports:
+      - "1025:1025"   # SMTP
+      - "8025:8025"   # Web UI
+    environment:
+      MP_MAX_MESSAGES: 5000
+      MP_SMTP_AUTH_ACCEPT_ANY: 1
+      MP_SMTP_AUTH_ALLOW_INSECURE: 1
+    networks:
+      - studybuddy-staging-network
+
 volumes:
   postgres_staging_data:
     driver: local
   weaviate_staging_data:
+    driver: local
+  redis_staging_data:
     driver: local
 
 networks:

--- a/docs/local-testing-guide.md
+++ b/docs/local-testing-guide.md
@@ -7,6 +7,16 @@ How to run Study Buddy end-to-end on your machine — including the JWT auth flo
 - Docker + Docker Compose
 - [uv](https://docs.astral.sh/uv/) (backend package manager)
 - [Bun](https://bun.com/) (frontend package manager)
+- GNU Make
+  - Debian/Ubuntu: `sudo apt install make`
+  - Arch: `sudo pacman -S make`
+  - macOS: comes with Xcode Command Line Tools (`xcode-select --install`)
+  - Windows: install via [Chocolatey](https://chocolatey.org/) (`choco install make`), [Scoop](https://scoop.sh/) (`scoop install make`), or just use WSL
+- `libmagic` (system library used for MIME-type detection on document upload)
+  - Debian/Ubuntu: `sudo apt install libmagic1`
+  - Arch: `sudo pacman -S file`
+  - macOS: `brew install libmagic`
+  - NixOS: add `pkgs.file` to your shell environment
 - `openssl` (for generating `SECRET_KEY`)
 
 ## 1. Environment Files
@@ -46,7 +56,7 @@ cd backend
 make db-up
 ```
 
-`db-up` runs `docker compose up -d` on the local compose file. Verify everything is healthy:
+`db-up` wraps `docker compose` against `docker/local/docker-compose.yml`. Verify everything is healthy:
 
 ```bash
 docker ps
@@ -108,6 +118,8 @@ bun dev                 # Next.js on port 3000
 | No email arrives in Mailpit | Mailpit container down | `docker ps` — restart with `make db-up` |
 | Login succeeds but `/me` returns 401 | Stale cookie from previous run | Clear cookies for `localhost:8001` |
 | Database errors after pulling code | New migrations not applied | `uv run alembic upgrade head` |
+| `password authentication failed for user "..."` on migrations | Postgres volume baked credentials from a previous run | `make db-reset` (drops volumes, recreates with current `.env`) |
+| Backend crashes with `ImportError: failed to find libmagic` | System library missing | Install libmagic — see Prerequisites |
 
 ## 8. Useful Make Targets
 


### PR DESCRIPTION
Documents the JWT auth system end-to-end and fixes a few dev-experience papercuts that surfaced while writing it up.

## Docs

- **`docs/local-testing-guide.md`** — new walkthrough for spinning up the full stack locally: prerequisites (Docker, uv, Bun, GNU Make, libmagic, openssl), env setup, `make` targets, service URLs, end-to-end auth flow via Mailpit, troubleshooting.
- **`docs/adr/0001-jwt-storage-strategy.md`** — rewritten in English, marks AUTH-11 as delivered, reflects the actual cookie path (`/api/auth`), backend port (`8001`), and production domain (`studybuddy.mojiverse.at`).
- **`backend/docs/auth-implementation.md`** — complete reference for the auth system: flow diagrams, schemas, security primitives, design-decision rationale, files map, issue map.
- **`backend/.env-example`** — expanded with JWT, refresh-cookie, mail, and frontend-base-url settings; local Postgres defaults now match `docker/local/.env`.

## Dev tooling

- **`backend/Makefile`** — `db-up`, `db-down`, `db-reset` now point explicitly at `docker/local/docker-compose.yml` and its `.env`, so they actually work from `backend/`.
- **`docker/server/staging/docker-compose.yml`** — Redis (required for JWT denylist / rate limiting) plus Mailpit (SMTP sink for safe testing) added.
- **`docker/server/prod/docker-compose.yml`** — Redis added. No Mailpit — production relies on a real SMTP provider via `.env`.