### PR TITLE
feat(docker): add minio to local compose for offline-friendly dev

### DIFF
--- a/backend/.env-example
+++ b/backend/.env-example
@@ -33,13 +33,13 @@ MAIL_FROM=no-reply@studybuddy.mojiverse.at
 MAIL_FROM_NAME=Study Buddy
 FRONTEND_BASE_URL=http://localhost:3000
 
-# MinIO
-MINIO_ENDPOINT=85.215.241.173:9000
+# MinIO (local docker compose service — Web UI on http://localhost:9001)
+MINIO_ENDPOINT=localhost:9000
 MINIO_ACCESS_KEY=studybuddy
-MINIO_SECRET_KEY=<MINIO_ROOT_PASSWORD>
-MINIO_BUCKET=test-documents
+MINIO_SECRET_KEY=studybuddy123
+MINIO_BUCKET=studybuddy-dev
 MINIO_SECURE=false
-MINIO_PUBLIC_URL=https://studybuddy.mojiverse.dev/files
+MINIO_PUBLIC_URL=http://localhost:9000
 
 # Weaviate (self-hosted, vectorizer=none — embeddings come from the backend)
 WEAVIATE_HTTP_HOST=localhost

--- a/docker/local/docker-compose.yml
+++ b/docker/local/docker-compose.yml
@@ -70,12 +70,35 @@ services:
     networks:
       - studybuddy-local-network
 
+  minio:
+    image: minio/minio
+    container_name: studybuddy-local-minio
+    restart: unless-stopped
+    environment:
+      MINIO_ROOT_USER: studybuddy
+      MINIO_ROOT_PASSWORD: studybuddy123
+    command: server /data --console-address ":9001"
+    volumes:
+      - minio_local_data:/data
+    ports:
+      - "9000:9000"   # S3 API
+      - "9001:9001"   # Web UI
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+    networks:
+      - studybuddy-local-network
+
 volumes:
   postgres_local_data:
     driver: local
   weaviate_local_data:
     driver: local
   redis_local_data:
+    driver: local
+  minio_local_data:
     driver: local
 
 networks:


### PR DESCRIPTION
- Adds MinIO as a local docker compose service so contributors can run uploads without production credentials
- Updates `backend/.env-example` MinIO defaults to point at the local container (`localhost:9000`, bucket `studybuddy-dev`)
- Web UI available on http://localhost:9001 for inspecting uploaded files